### PR TITLE
Remove timestamp check for latency metrics - support for multiple prometheus scrapes

### DIFF
--- a/latency_parser.go
+++ b/latency_parser.go
@@ -37,7 +37,7 @@ func parseLatencyInfo(s string) map[string]StatsMap {
 			break
 		}
 
-		timestamp, err := ip.ReadUntil(',')
+		_, err = ip.ReadUntil(',')
 		if err != nil {
 			break
 		}
@@ -92,7 +92,6 @@ func parseLatencyInfo(s string) map[string]StatsMap {
 
 		stats := StatsMap{
 			"tps":        opsCount,
-			"timestamp":  timestamp,
 			"buckets":    buckets,
 			"valBuckets": valBucketsFloat,
 		}


### PR DESCRIPTION
In a [multi prometheus setup (HA setup)](https://prometheus.io/docs/introduction/faq/#can-prometheus-be-made-highly-available), we must export all metrics to each prometheus server. 

The timestamp check for latency prevents exporting metrics to more than one prometheus server.

The latency data gets updated every 10s (default [hist-track-slice](https://www.aerospike.com/docs/reference/configuration/index.html#hist-track-slice)) on aerospike server and it's okay if we send multiple times to prometheus for multiple requests that arrives within this 10s. But we must send if there are multiple prometheus servers scraping the same target.