### PR TITLE
make normalized non-utf-8 labels unique

### DIFF
--- a/common.go
+++ b/common.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -197,5 +198,5 @@ func sanitizeUTF8(lv string) string {
 		return r
 	}
 
-	return strings.Map(fixUtf, lv)
+	return strings.Map(fixUtf, lv) + " " + hex.EncodeToString([]byte(lv))
 }


### PR DESCRIPTION
Normalized label names may not be unique which causes problems. I have added original string hex to make them unique and consistent. Connected to https://github.com/alicebob/asprom/pull/44