### PR TITLE
[TOOLS-2221] Arm64 support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM golang:1.16-alpine AS builder
 
-ARG TARGETARCH
-ARG TARGETOS
 ARG VERSION=v1.9.0
 
 ADD . $GOPATH/src/github.com/aerospike/aerospike-prometheus-exporter
 WORKDIR $GOPATH/src/github.com/aerospike/aerospike-prometheus-exporter
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X 'main.version=$VERSION'" -o aerospike-prometheus-exporter . \
+RUN go build -ldflags="-X 'main.version=$VERSION'" -o aerospike-prometheus-exporter . \
 	&& cp aerospike-prometheus-exporter /aerospike-prometheus-exporter
 
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.16-alpine AS builder
 
+ARG TARGETARCH
+ARG TARGETOS
 ARG VERSION=v1.9.0
 
 ADD . $GOPATH/src/github.com/aerospike/aerospike-prometheus-exporter
 WORKDIR $GOPATH/src/github.com/aerospike/aerospike-prometheus-exporter
-RUN go build -ldflags="-X 'main.version=$VERSION'" -o aerospike-prometheus-exporter . \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X 'main.version=$VERSION'" -o aerospike-prometheus-exporter . \
 	&& cp aerospike-prometheus-exporter /aerospike-prometheus-exporter
 
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.16-alpine AS builder
 
-ARG VERSION=v1.5.2
+ARG VERSION=v1.9.0
 
 ADD . $GOPATH/src/github.com/aerospike/aerospike-prometheus-exporter
 WORKDIR $GOPATH/src/github.com/aerospike/aerospike-prometheus-exporter

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,11 @@ docker:
 .PHONY: release-docker-multi-arch
 release-docker-multi-arch:
 	docker buildx build --build-arg VERSION=$(VERSION) --platform $(DOCKER_MULTI_ARCH_PLATFORMS) --push . -t aerospike/aerospike-prometheus-exporter:latest -t aerospike/aerospike-prometheus-exporter:$(VERSION)
+
+.PHONY: package-linux-arm64
+package-linux-arm64:
+	$(MAKE) deb rpm tar GOOS=linux GOARCH=arm64 DEB_PKG_ARCH=arm64 ARCH=arm64
+
+.PHONY: package-linux-amd64
+package-linux-amd64:
+	$(MAKE) deb rpm tar GOOS=linux GOARCH=amd64 DEB_PKG_ARCH=amd64 ARCH=x86_64

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION = $(shell git describe --tags --always)
 # Builds exporter binary
 .PHONY: exporter
 exporter:
-	go build -ldflags="-X 'main.version=$(VERSION)'" -o aerospike-prometheus-exporter .
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags="-X 'main.version=$(VERSION)'" -o aerospike-prometheus-exporter .
 
 # Builds RPM, DEB and TAR packages
 # Requires FPM package manager

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
 # Variables required for this Makefile
 ROOT_DIR = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 VERSION = $(shell git describe --tags --always)
+GO_ENV_VARS =
+
+ifdef GOOS
+GO_ENV_VARS = GOOS=$(GOOS)
+endif
+
+ifdef GOARCH
+GO_ENV_VARS += GOARCH=$(GOARCH)
+endif
+
+DOCKER_MULTI_ARCH_PLATFORMS = linux/amd64,linux/arm64
 
 # Builds exporter binary
 .PHONY: exporter
 exporter:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags="-X 'main.version=$(VERSION)'" -o aerospike-prometheus-exporter .
+	$(GO_ENV_VARS) go build -ldflags="-X 'main.version=$(VERSION)'" -o aerospike-prometheus-exporter .
 
 # Builds RPM, DEB and TAR packages
 # Requires FPM package manager
@@ -32,3 +43,9 @@ clean:
 .PHONY: docker
 docker:
 	docker build --build-arg VERSION=$(VERSION) . -t aerospike/aerospike-prometheus-exporter:latest
+
+# NOTE: this builds and pushes the image to aerospike/aerospike-prometheus-exporter docker hub repository
+# Use this target only for release
+.PHONY: release-docker-multi-arch
+release-docker-multi-arch:
+	docker buildx build --build-arg VERSION=$(VERSION) --platform $(DOCKER_MULTI_ARCH_PLATFORMS) --push . -t aerospike/aerospike-prometheus-exporter:latest -t aerospike/aerospike-prometheus-exporter:$(VERSION)

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var (
 	fullHost string
 	config   *Config
 
-	version = "v1.5.2"
+	version = "v1.9.0"
 )
 
 func main() {

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -12,6 +12,8 @@ DESCRIPTION = "Aerospike Prometheus Exporter, An agent to export Aerospike metri
 LICENSE = "Apache License 2.0"
 URL = "https://github.com/aerospike/aerospike-prometheus-exporter"
 VENDOR = "Aerospike, Inc."
+ARCH ?= $(shell uname -m)
+DEB_PKG_ARCH ?= $(shell dpkg-architecture -q DEB_BUILD_ARCH)
 
 
 .PHONY: all
@@ -32,7 +34,8 @@ deb: prep
 		--license $(LICENSE) \
 		--url $(URL) \
 		--vendor $(VENDOR) \
-		--package $(TARGET_DIR)/aerospike-prometheus-exporter-$(VERSION)-amd64.deb
+		--architecture $(DEB_PKG_ARCH) \
+		--package $(TARGET_DIR)/aerospike-prometheus-exporter-$(VERSION)-$(DEB_PKG_ARCH).deb
 
 .PHONY: rpm
 rpm: prep
@@ -49,7 +52,8 @@ rpm: prep
 		--license $(LICENSE) \
 		--url $(URL) \
 		--vendor $(VENDOR) \
-		--package $(TARGET_DIR)/aerospike-prometheus-exporter-$(VERSION)-x86_64.rpm
+		--architecture $(ARCH) \
+		--package $(TARGET_DIR)/aerospike-prometheus-exporter-$(VERSION)-$(ARCH).rpm
 
 .PHONY: tar
 tar: prep

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -70,7 +70,7 @@ tar: prep
 		--license $(LICENSE) \
 		--url $(URL) \
 		--vendor $(VENDOR) \
-		--package $(TARGET_DIR)/aerospike-prometheus-exporter-$(VERSION).tar
+		--package $(TARGET_DIR)/aerospike-prometheus-exporter-$(VERSION)-$(ARCH).tar
 
 .PHONY: prep
 prep:


### PR DESCRIPTION
Make it possible to set the package architecture manually or automatically. This makes cross compiling easier.
Increment docker file version to v1.9.0. I intend to use v1.9.0 to mark arm support (including arm docker images).