### PR TITLE
OM-39 - Using "xz" compression for debian (deb) packages

### DIFF
--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -48,6 +48,7 @@ deb: prep
 		--config-files /etc/aerospike-prometheus-exporter \
 		--input-type dir \
 		--output-type deb \
+		--deb-compression xz \
 		--chdir $(BUILD_DIR)/ \
 		--after-install $(PKG_DIR)/post-install.sh \
 		--name $(NAME) \


### PR DESCRIPTION
Ubuntu 22 default compression is not "xz" and will break our gpg signature.  This change will ensure that we always use "xz" compression for deb package.  It's not an issue now but it will be when ubuntu22 is on.