### PR TITLE
Om36 - allowlist and blocklist for latencies

### DIFF
--- a/ape.toml
+++ b/ape.toml
@@ -112,50 +112,39 @@ latency_buckets_count = 0
 # Metrics Allowlist - If specified, only these metrics will be scraped. An empty list will exclude all metrics.
 # Commenting out the below allowlist configs will disable metrics filtering (i.e. all metrics will be scraped).
 
-# Metrics Blocklist - If specified, If specified, these metrics will be NOT be scraped. An empty list will include all metrics.
+# Metrics Blocklist - If specified, these metrics will be NOT be scraped. An empty list will include all metrics.
 # Commenting out the below blocklist configs will disable metrics filtering (i.e. no metrics will be blocked/filtered).
+
+# globbing pattern (wildcard) are allowd for allowlist and blocklist
+# for example "batch_index_*_buffers"
 
 # Namespace metrics allowlist, to control which Namespace metrics should be collected.
 # namespace_metrics_allowlist = []
-# Namespace metrics blocklist, If specified, these Namespace metrics will be NOT be scraped.
 # namespace_metrics_blocklist = []
 
-# Set metrics allowlist, to control which Set metrics should be collected.
 # set_metrics_allowlist = []
-# Set metrics blocklist, If specified, these Set metrics will be NOT be scraped.
 # set_metrics_blocklist = []
 
 # Latencies histogram allowlist, to control which Histogram-name metrics should be collected. 
-# Note: globbing patterns are not supported for this latency metric configuration. 
+# Note: globbing patterns (wildcard) are not supported for this latency metric configuration. 
 # latencies_metrics_allowlist = []
-# Latencies histogram blocklist, If specified a Histogram-name those metrics will be NOT be scraped.
-# Note: globbing patterns are not supported for this latency metric configuration. 
 # latencies_metrics_blocklist = []
 
-# Node metrics allowlist, to control which Node metrics should be collected.
 # node_metrics_allowlist = []
-# Node metrics blocklist, If specified, these Node metrics will be NOT be scraped.
 # node_metrics_blocklist = []
 
-# XDR metrics allowlist (only for Aerospike versions 5.0 and above), to control which XDR metrics should be collected.
+# Support only from Aerospike versions 5.0 and above
 # xdr_metrics_allowlist = []
-# XDR metrics blocklist (only for Aerospike versions 5.0 and above), If specified, these metrics will be NOT be scraped.
 # xdr_metrics_blocklist = []
 
-# Users allowlist ((user statistics are available in Aerospike 5.6+)) to control which users specific metrics should be collected.
-# Note globbing patterns are not supported for this User configuration.
+# User statistics are available in Aerospike 5.6+
+# Note globbing patterns (wildcard) are not supported for this User configuration.
 # user_metrics_users_allowlist = []
-# Users metrics blocklist (user statistics are available in Aerospike 5.6+), If specified, these User specific metrics will be NOT be scraped.
-# Note globbing patterns are not supported for this User configuration.
 # user_metrics_users_blocklist = []
 
-# Job (scans/queries) metrics allowlist, to control which Job metrics should be collected.
 # job_metrics_allowlist = []
-# Job (scans/queries) metrics blocklist, If specified, these Job metrics will be NOT be scraped.
 # job_metrics_blocklist = []
 
-# Secondary index metrics allowlist, to control which Secondary index metrics should be collected.
 # sindex_metrics_allowlist = []
-# Secondary index metrics blocklist, If specified, these Secondary index metrics will be NOT be scraped.
 # sindex_metrics_blocklist = []
 

--- a/ape.toml
+++ b/ape.toml
@@ -128,6 +128,9 @@ latency_buckets_count = 0
 # Secondary index metrics allowlist
 # sindex_metrics_allowlist = []
 
+# Latencies metrics allowlist
+# latencies_metrics_allowlist = []
+
 # Metrics Blocklist - If specified, these metrics will be NOT be scraped.
 
 # Namespace metrics blocklist
@@ -147,6 +150,9 @@ latency_buckets_count = 0
 
 # Secondary index metrics blocklist
 # sindex_metrics_blocklist = []
+
+# latencies metrics blocklist
+# latencies_metrics_blocklist = []
 
 # Users Statistics (user statistics are available in Aerospike 5.6+)
 # Users Allowlist and Blocklist to control for which users their statistics should be collected.

--- a/ape.toml
+++ b/ape.toml
@@ -128,9 +128,6 @@ latency_buckets_count = 0
 # Secondary index metrics allowlist
 # sindex_metrics_allowlist = []
 
-# Latencies metrics allowlist
-# latencies_metrics_allowlist = []
-
 # Metrics Blocklist - If specified, these metrics will be NOT be scraped.
 
 # Namespace metrics blocklist
@@ -151,12 +148,16 @@ latency_buckets_count = 0
 # Secondary index metrics blocklist
 # sindex_metrics_blocklist = []
 
-# latencies metrics blocklist
-# latencies_metrics_blocklist = []
-
 # Users Statistics (user statistics are available in Aerospike 5.6+)
 # Users Allowlist and Blocklist to control for which users their statistics should be collected.
 # Note globbing patterns are not supported for this configuration.
 
 # user_metrics_users_allowlist = []
 # user_metrics_users_blocklist = []
+
+# Latencies Allowlist and Blocklist to control for which histogram statistics should be collected. 
+# we configure histogram-names, Note globbing patterns are not supported for this configuration. 
+# latencies_metrics_allowlist = []
+# latencies_metrics_blocklist = []
+
+

--- a/ape.toml
+++ b/ape.toml
@@ -156,7 +156,8 @@ latency_buckets_count = 0
 # user_metrics_users_blocklist = []
 
 # Latencies Allowlist and Blocklist to control for which histogram statistics should be collected. 
-# we configure histogram-names, Note globbing patterns are not supported for this configuration. 
+# We configure histogram-names
+# Note: globbing patterns are not supported for this configuration. 
 # latencies_metrics_allowlist = []
 # latencies_metrics_blocklist = []
 

--- a/ape.toml
+++ b/ape.toml
@@ -107,58 +107,55 @@ timeout = 5
 # Default: 0 (export all threshold buckets).
 latency_buckets_count = 0
 
+# Order of context - namespace, set, latencies, node-stats, xdr, user, jobs, sindex
+
 # Metrics Allowlist - If specified, only these metrics will be scraped. An empty list will exclude all metrics.
 # Commenting out the below allowlist configs will disable metrics filtering (i.e. all metrics will be scraped).
 
-# Namespace metrics allowlist
+# Metrics Blocklist - If specified, If specified, these metrics will be NOT be scraped. An empty list will include all metrics.
+# Commenting out the below blocklist configs will disable metrics filtering (i.e. no metrics will be blocked/filtered).
+
+# Namespace metrics allowlist, to control which Namespace metrics should be collected.
 # namespace_metrics_allowlist = []
-
-# Set metrics allowlist
-# set_metrics_allowlist = []
-
-# Node metrics allowlist
-# node_metrics_allowlist = []
-
-# XDR metrics allowlist (only for Aerospike versions 5.0 and above)
-# xdr_metrics_allowlist = []
-
-# Job (scans/queries) metrics allowlist
-# job_metrics_allowlist = []
-
-# Secondary index metrics allowlist
-# sindex_metrics_allowlist = []
-
-# Metrics Blocklist - If specified, these metrics will be NOT be scraped.
-
-# Namespace metrics blocklist
+# Namespace metrics blocklist, If specified, these Namespace metrics will be NOT be scraped.
 # namespace_metrics_blocklist = []
 
-# Set metrics blocklist
+# Set metrics allowlist, to control which Set metrics should be collected.
+# set_metrics_allowlist = []
+# Set metrics blocklist, If specified, these Set metrics will be NOT be scraped.
 # set_metrics_blocklist = []
 
-# Node metrics blocklist
-# node_metrics_blocklist = []
-
-# XDR metrics blocklist (only for Aerospike versions 5.0 and above)
-# xdr_metrics_blocklist = []
-
-# Job (scans/queries) metrics blocklist
-# job_metrics_blocklist = []
-
-# Secondary index metrics blocklist
-# sindex_metrics_blocklist = []
-
-# Users Statistics (user statistics are available in Aerospike 5.6+)
-# Users Allowlist and Blocklist to control for which users their statistics should be collected.
-# Note globbing patterns are not supported for this configuration.
-
-# user_metrics_users_allowlist = []
-# user_metrics_users_blocklist = []
-
-# Latencies Allowlist and Blocklist to control for which histogram statistics should be collected. 
-# We configure histogram-names
-# Note: globbing patterns are not supported for this configuration. 
+# Latencies histogram allowlist, to control which Histogram-name metrics should be collected. 
+# Note: globbing patterns are not supported for this latency metric configuration. 
 # latencies_metrics_allowlist = []
+# Latencies histogram blocklist, If specified a Histogram-name those metrics will be NOT be scraped.
+# Note: globbing patterns are not supported for this latency metric configuration. 
 # latencies_metrics_blocklist = []
 
+# Node metrics allowlist, to control which Node metrics should be collected.
+# node_metrics_allowlist = []
+# Node metrics blocklist, If specified, these Node metrics will be NOT be scraped.
+# node_metrics_blocklist = []
+
+# XDR metrics allowlist (only for Aerospike versions 5.0 and above), to control which XDR metrics should be collected.
+# xdr_metrics_allowlist = []
+# XDR metrics blocklist (only for Aerospike versions 5.0 and above), If specified, these metrics will be NOT be scraped.
+# xdr_metrics_blocklist = []
+
+# Users allowlist ((user statistics are available in Aerospike 5.6+)) to control which users specific metrics should be collected.
+# Note globbing patterns are not supported for this User configuration.
+# user_metrics_users_allowlist = []
+# Users metrics blocklist (user statistics are available in Aerospike 5.6+), If specified, these User specific metrics will be NOT be scraped.
+# Note globbing patterns are not supported for this User configuration.
+# user_metrics_users_blocklist = []
+
+# Job (scans/queries) metrics allowlist, to control which Job metrics should be collected.
+# job_metrics_allowlist = []
+# Job (scans/queries) metrics blocklist, If specified, these Job metrics will be NOT be scraped.
+# job_metrics_blocklist = []
+
+# Secondary index metrics allowlist, to control which Secondary index metrics should be collected.
+# sindex_metrics_allowlist = []
+# Secondary index metrics blocklist, If specified, these Secondary index metrics will be NOT be scraped.
+# sindex_metrics_blocklist = []
 

--- a/config.go
+++ b/config.go
@@ -64,18 +64,18 @@ type Config struct {
 		SindexMetricsAllowlistEnabled bool
 		SindexMetricsBlocklistEnabled bool
 
-		// Latencies Allow and Block list
-		LatenciesMetricsAllowlistEnabled bool
-		LatenciesMetricsAllowlist        []string `toml:"latencies_metrics_allowlist"`
+		// knob to disable sindex metrics collection (for internal use only, will be deprecated)
+		DisableSindexMetrics bool `toml:"disable_sindex_metrics"`
 
+		// Latencies Allow and Block list
+		LatenciesMetricsAllowlist []string `toml:"latencies_metrics_allowlist"`
+		LatenciesMetricsBlocklist []string `toml:"latencies_metrics_blocklist"`
+
+		LatenciesMetricsAllowlistEnabled bool
 		LatenciesMetricsBlocklistEnabled bool
-		LatenciesMetricsBlocklist        []string `toml:"latencies_metrics_blocklist"`
 
 		// knob to disable latencies metrics collection (for internal use only, will be deprecated)
 		DisableLatenciesMetrics bool `toml:"disable_latencies_metrics"`
-
-		// knob to disable sindex metrics collection (for internal use only, will be deprecated)
-		DisableSindexMetrics bool `toml:"disable_sindex_metrics"`
 
 		UserMetricsUsersAllowlist []string `toml:"user_metrics_users_allowlist"`
 		UserMetricsUsersBlocklist []string `toml:"user_metrics_users_blocklist"`
@@ -300,25 +300,4 @@ func initAllowlistAndBlocklistConfigs(config *Config, md toml.MetaData) {
 		config.Aerospike.XdrMetricsBlocklistEnabled = true
 		config.Aerospike.XdrMetricsBlocklist = config.Aerospike.XdrMetricsBlacklist
 	}
-
-	// Latencies -- Is this required - as this feature was not available in previous versions
-	if md.IsDefined("Aerospike", "latencies_metrics_whitelist") {
-		if config.Aerospike.LatenciesMetricsAllowlistEnabled {
-			log.Fatalf("latencies_metrics_whitelist and latencies_metrics_allowlist are mutually exclusive!")
-		}
-
-		config.Aerospike.LatenciesMetricsAllowlistEnabled = true
-		config.Aerospike.LatenciesMetricsAllowlist = config.Aerospike.LatenciesMetricsWhitelist
-	}
-
-	// Latencies -- Is this required - as this feature was not available in previous versions
-	if md.IsDefined("Aerospike", "latencies_metrics_blacklist") {
-		if config.Aerospike.LatenciesMetricsBlocklistEnabled {
-			log.Fatalf("latencies_metrics_blacklist and latencies_metrics_blocklist are mutually exclusive!")
-		}
-
-		config.Aerospike.LatenciesMetricsBlocklistEnabled = true
-		config.Aerospike.LatenciesMetricsBlocklist = config.Aerospike.NamespaceMetricsBlacklist
-	}
-
 }

--- a/config.go
+++ b/config.go
@@ -49,25 +49,22 @@ type Config struct {
 
 		LatencyBucketsCount uint8 `toml:"latency_buckets_count"`
 
-		JobMetricsAllowlist []string `toml:"job_metrics_allowlist"`
-		JobMetricsBlocklist []string `toml:"job_metrics_blocklist"`
+		// Order of context ( from observer.go) - namespace, set, latencies, node-stats, xdr, user, jobs, sindex
+		// Namespace metrics allow/block
+		NamespaceMetricsAllowlist []string `toml:"namespace_metrics_allowlist"`
+		NamespaceMetricsBlocklist []string `toml:"namespace_metrics_blocklist"`
 
-		JobMetricsAllowlistEnabled bool
-		JobMetricsBlocklistEnabled bool
+		NamespaceMetricsAllowlistEnabled bool
+		NamespaceMetricsBlocklistEnabled bool
 
-		// knob to disable job metrics collection (for internal use only, will be deprecated)
-		DisableJobMetrics bool `toml:"disable_job_metrics"`
+		// Set metrics allow/block
+		SetMetricsAllowlist []string `toml:"set_metrics_allowlist"`
+		SetMetricsBlocklist []string `toml:"set_metrics_blocklist"`
 
-		SindexMetricsAllowlist []string `toml:"sindex_metrics_allowlist"`
-		SindexMetricsBlocklist []string `toml:"sindex_metrics_blocklist"`
+		SetMetricsAllowlistEnabled bool
+		SetMetricsBlocklistEnabled bool
 
-		SindexMetricsAllowlistEnabled bool
-		SindexMetricsBlocklistEnabled bool
-
-		// knob to disable sindex metrics collection (for internal use only, will be deprecated)
-		DisableSindexMetrics bool `toml:"disable_sindex_metrics"`
-
-		// Latencies Allow and Block list
+		// Latencies metrics allow/block
 		LatenciesMetricsAllowlist []string `toml:"latencies_metrics_allowlist"`
 		LatenciesMetricsBlocklist []string `toml:"latencies_metrics_blocklist"`
 
@@ -77,31 +74,46 @@ type Config struct {
 		// knob to disable latencies metrics collection (for internal use only, will be deprecated)
 		DisableLatenciesMetrics bool `toml:"disable_latencies_metrics"`
 
+		// Node metrics allow/block
+		NodeMetricsAllowlist []string `toml:"node_metrics_allowlist"`
+		NodeMetricsBlocklist []string `toml:"node_metrics_blocklist"`
+
+		NodeMetricsAllowlistEnabled bool
+		NodeMetricsBlocklistEnabled bool
+
+		// Xdr metrics allow/block
+		XdrMetricsAllowlist []string `toml:"xdr_metrics_allowlist"`
+		XdrMetricsBlocklist []string `toml:"xdr_metrics_blocklist"`
+
+		XdrMetricsAllowlistEnabled bool
+		XdrMetricsBlocklistEnabled bool
+
+		// User metrics allow/block
 		UserMetricsUsersAllowlist []string `toml:"user_metrics_users_allowlist"`
 		UserMetricsUsersBlocklist []string `toml:"user_metrics_users_blocklist"`
 
 		UserMetricsUsersAllowlistEnabled bool
 		UserMetricsUsersBlocklistEnabled bool
 
-		NamespaceMetricsAllowlist []string `toml:"namespace_metrics_allowlist"`
-		SetMetricsAllowlist       []string `toml:"set_metrics_allowlist"`
-		NodeMetricsAllowlist      []string `toml:"node_metrics_allowlist"`
-		XdrMetricsAllowlist       []string `toml:"xdr_metrics_allowlist"`
+		// Job metrics allow/block
+		JobMetricsAllowlist []string `toml:"job_metrics_allowlist"`
+		JobMetricsBlocklist []string `toml:"job_metrics_blocklist"`
 
-		NamespaceMetricsAllowlistEnabled bool
-		SetMetricsAllowlistEnabled       bool
-		NodeMetricsAllowlistEnabled      bool
-		XdrMetricsAllowlistEnabled       bool
+		JobMetricsAllowlistEnabled bool
+		JobMetricsBlocklistEnabled bool
 
-		NamespaceMetricsBlocklist []string `toml:"namespace_metrics_blocklist"`
-		SetMetricsBlocklist       []string `toml:"set_metrics_blocklist"`
-		NodeMetricsBlocklist      []string `toml:"node_metrics_blocklist"`
-		XdrMetricsBlocklist       []string `toml:"xdr_metrics_blocklist"`
+		// knob to disable job metrics collection (for internal use only, will be deprecated)
+		DisableJobMetrics bool `toml:"disable_job_metrics"`
 
-		NamespaceMetricsBlocklistEnabled bool
-		SetMetricsBlocklistEnabled       bool
-		NodeMetricsBlocklistEnabled      bool
-		XdrMetricsBlocklistEnabled       bool
+		// Sindex metrics allow/block
+		SindexMetricsAllowlist []string `toml:"sindex_metrics_allowlist"`
+		SindexMetricsBlocklist []string `toml:"sindex_metrics_blocklist"`
+
+		SindexMetricsAllowlistEnabled bool
+		SindexMetricsBlocklistEnabled bool
+
+		// knob to disable sindex metrics collection (for internal use only, will be deprecated)
+		DisableSindexMetrics bool `toml:"disable_sindex_metrics"`
 
 		// Tolerate older whitelist and blacklist configurations for a while
 		NamespaceMetricsWhitelist []string `toml:"namespace_metrics_whitelist"`

--- a/config.go
+++ b/config.go
@@ -71,6 +71,9 @@ type Config struct {
 		LatenciesMetricsBlocklistEnabled bool
 		LatenciesMetricsBlocklist        []string `toml:"latencies_metrics_blocklist"`
 
+		// knob to disable latencies metrics collection (for internal use only, will be deprecated)
+		DisableLatenciesMetrics bool `toml:"disable_latencies_metrics"`
+
 		// knob to disable sindex metrics collection (for internal use only, will be deprecated)
 		DisableSindexMetrics bool `toml:"disable_sindex_metrics"`
 
@@ -215,7 +218,7 @@ func initAllowlistAndBlocklistConfigs(config *Config, md toml.MetaData) {
 	config.Aerospike.SindexMetricsBlocklistEnabled = md.IsDefined("Aerospike", "sindex_metrics_blocklist")
 
 	config.Aerospike.LatenciesMetricsAllowlistEnabled = md.IsDefined("Aerospike", "latencies_metrics_allowlist")
-	config.Aerospike.LatenciesMetricsBlocklistEnabled = md.IsDefined("Aerospike", "sindex_metrics_blocklist")
+	config.Aerospike.LatenciesMetricsBlocklistEnabled = md.IsDefined("Aerospike", "latencies_metrics_blocklist")
 
 	// Initialize BlocklistEnabled config
 	config.Aerospike.NamespaceMetricsBlocklistEnabled = md.IsDefined("Aerospike", "namespace_metrics_blocklist")
@@ -299,13 +302,23 @@ func initAllowlistAndBlocklistConfigs(config *Config, md toml.MetaData) {
 	}
 
 	// Latencies -- Is this required - as this feature was not available in previous versions
-	if md.IsDefined("Aerospike", "latencies_metrics_allowlist") {
+	if md.IsDefined("Aerospike", "latencies_metrics_whitelist") {
 		if config.Aerospike.LatenciesMetricsAllowlistEnabled {
 			log.Fatalf("latencies_metrics_whitelist and latencies_metrics_allowlist are mutually exclusive!")
 		}
 
 		config.Aerospike.LatenciesMetricsAllowlistEnabled = true
-		config.Aerospike.LatenciesMetricsAllowlist = config.Aerospike.NamespaceMetricsWhitelist
+		config.Aerospike.LatenciesMetricsAllowlist = config.Aerospike.LatenciesMetricsWhitelist
+	}
+
+	// Latencies -- Is this required - as this feature was not available in previous versions
+	if md.IsDefined("Aerospike", "latencies_metrics_blacklist") {
+		if config.Aerospike.LatenciesMetricsBlocklistEnabled {
+			log.Fatalf("latencies_metrics_blacklist and latencies_metrics_blocklist are mutually exclusive!")
+		}
+
+		config.Aerospike.LatenciesMetricsBlocklistEnabled = true
+		config.Aerospike.LatenciesMetricsBlocklist = config.Aerospike.NamespaceMetricsBlacklist
 	}
 
 }

--- a/config.go
+++ b/config.go
@@ -108,13 +108,11 @@ type Config struct {
 		SetMetricsWhitelist       []string `toml:"set_metrics_whitelist"`
 		NodeMetricsWhitelist      []string `toml:"node_metrics_whitelist"`
 		XdrMetricsWhitelist       []string `toml:"xdr_metrics_whitelist"`
-		LatenciesMetricsWhitelist []string `toml:"latencies_metrics_whitelist"`
 
 		NamespaceMetricsBlacklist []string `toml:"namespace_metrics_blacklist"`
 		SetMetricsBlacklist       []string `toml:"set_metrics_blacklist"`
 		NodeMetricsBlacklist      []string `toml:"node_metrics_blacklist"`
 		XdrMetricsBlacklist       []string `toml:"xdr_metrics_blacklist"`
-		LatenciesMetricsBlacklist []string `toml:"latencies_metrics_blacklist"`
 	} `toml:"Aerospike"`
 
 	LogFile *os.File

--- a/config.go
+++ b/config.go
@@ -64,6 +64,13 @@ type Config struct {
 		SindexMetricsAllowlistEnabled bool
 		SindexMetricsBlocklistEnabled bool
 
+		// Latencies Allow and Block list
+		LatenciesMetricsAllowlistEnabled bool
+		LatenciesMetricsAllowlist        []string `toml:"latencies_metrics_allowlist"`
+
+		LatenciesMetricsBlocklistEnabled bool
+		LatenciesMetricsBlocklist        []string `toml:"latencies_metrics_blocklist"`
+
 		// knob to disable sindex metrics collection (for internal use only, will be deprecated)
 		DisableSindexMetrics bool `toml:"disable_sindex_metrics"`
 
@@ -98,11 +105,13 @@ type Config struct {
 		SetMetricsWhitelist       []string `toml:"set_metrics_whitelist"`
 		NodeMetricsWhitelist      []string `toml:"node_metrics_whitelist"`
 		XdrMetricsWhitelist       []string `toml:"xdr_metrics_whitelist"`
+		LatenciesMetricsWhitelist []string `toml:"latencies_metrics_whitelist"`
 
 		NamespaceMetricsBlacklist []string `toml:"namespace_metrics_blacklist"`
 		SetMetricsBlacklist       []string `toml:"set_metrics_blacklist"`
 		NodeMetricsBlacklist      []string `toml:"node_metrics_blacklist"`
 		XdrMetricsBlacklist       []string `toml:"xdr_metrics_blacklist"`
+		LatenciesMetricsBlacklist []string `toml:"latencies_metrics_blacklist"`
 	} `toml:"Aerospike"`
 
 	LogFile *os.File
@@ -205,6 +214,9 @@ func initAllowlistAndBlocklistConfigs(config *Config, md toml.MetaData) {
 	config.Aerospike.SindexMetricsAllowlistEnabled = md.IsDefined("Aerospike", "sindex_metrics_allowlist")
 	config.Aerospike.SindexMetricsBlocklistEnabled = md.IsDefined("Aerospike", "sindex_metrics_blocklist")
 
+	config.Aerospike.LatenciesMetricsAllowlistEnabled = md.IsDefined("Aerospike", "latencies_metrics_allowlist")
+	config.Aerospike.LatenciesMetricsBlocklistEnabled = md.IsDefined("Aerospike", "sindex_metrics_blocklist")
+
 	// Initialize BlocklistEnabled config
 	config.Aerospike.NamespaceMetricsBlocklistEnabled = md.IsDefined("Aerospike", "namespace_metrics_blocklist")
 	config.Aerospike.SetMetricsBlocklistEnabled = md.IsDefined("Aerospike", "set_metrics_blocklist")
@@ -285,4 +297,15 @@ func initAllowlistAndBlocklistConfigs(config *Config, md toml.MetaData) {
 		config.Aerospike.XdrMetricsBlocklistEnabled = true
 		config.Aerospike.XdrMetricsBlocklist = config.Aerospike.XdrMetricsBlacklist
 	}
+
+	// Latencies -- Is this required - as this feature was not available in previous versions
+	if md.IsDefined("Aerospike", "latencies_metrics_allowlist") {
+		if config.Aerospike.LatenciesMetricsAllowlistEnabled {
+			log.Fatalf("latencies_metrics_whitelist and latencies_metrics_allowlist are mutually exclusive!")
+		}
+
+		config.Aerospike.LatenciesMetricsAllowlistEnabled = true
+		config.Aerospike.LatenciesMetricsAllowlist = config.Aerospike.NamespaceMetricsWhitelist
+	}
+
 }

--- a/observer.go
+++ b/observer.go
@@ -149,7 +149,7 @@ func newObserver(server *aero.Host, user, pass string) (o *Observer, err error) 
 		watchers: []Watcher{
 			&NamespaceWatcher{},
 			&SetWatcher{},
-			&LatencyWatcher{},
+			&LatencyWatcher{}, // gets the build version, used by watchers below
 			&StatsWatcher{},
 			&XdrWatcher{},
 			&UserWatcher{},

--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -9,6 +9,11 @@ import (
 type LatencyWatcher struct {
 }
 
+var latenciesRawMetrics = map[string]metricType{}
+
+// Filtered namespace metrics. Populated by getFilteredMetrics() based on the config.Aerospike.LatenciesMetricsAllowlist, config.Aerospike.LatenciesMetricsBlocklist and namespaceRawMetrics.
+var latenciesMetrics map[string]metricType
+
 func (lw *LatencyWatcher) describe(ch chan<- *prometheus.Desc) {}
 
 func (lw *LatencyWatcher) passOneKeys() []string {
@@ -32,6 +37,11 @@ func (lw *LatencyWatcher) passTwoKeys(rawMetrics map[string]string) (latencyComm
 }
 
 func (lw *LatencyWatcher) refresh(o *Observer, infoKeys []string, rawMetrics map[string]string, ch chan<- prometheus.Metric) error {
+
+	if latenciesMetrics == nil {
+		latenciesMetrics = getFilteredMetrics(latenciesRawMetrics, config.Aerospike.LatenciesMetricsAllowlist, config.Aerospike.LatenciesMetricsAllowlistEnabled, config.Aerospike.NamespaceMetricsBlocklist, config.Aerospike.NamespaceMetricsBlocklistEnabled)
+	}
+
 	var latencyStats map[string]StatsMap
 
 	if rawMetrics["latencies:"] != "" {

--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	log "github.com/sirupsen/logrus"
@@ -10,11 +8,6 @@ import (
 
 type LatencyWatcher struct {
 }
-
-var latenciesRawMetrics = map[string]metricType{}
-
-// Filtered namespace metrics. Populated by getFilteredMetrics() based on the config.Aerospike.LatenciesMetricsAllowlist, config.Aerospike.LatenciesMetricsBlocklist and namespaceRawMetrics.
-var latenciesMetrics map[string]metricType
 
 func (lw *LatencyWatcher) describe(ch chan<- *prometheus.Desc) {}
 
@@ -27,7 +20,6 @@ func (lw *LatencyWatcher) passTwoKeys(rawMetrics map[string]string) (latencyComm
 	// return if this feature is disabled.
 	if config.Aerospike.DisableLatenciesMetrics {
 		// disabled
-		fmt.Println("latencies refresh is disabled")
 		return nil
 	}
 


### PR DESCRIPTION
modified ape.toml to include configuration for latencies allowlist and blocklist.
watcher_latencies is modified to send or block histograms according to the histogram names mentioned in allowlist of blocklist.
also added key disable_latencies_metrics to switch-off / switch-on latency metrics ( this is similar to sindex and job key) this key is undocumented and not mentioned in the ape.toml also.