### PR TITLE
[OM-66] Add golang linter and address initial checks

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,0 +1,27 @@
+name: Lint
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.20
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.52.2
+          args: --timeout 6m0s --verbose -- ./...
+          only-new-issues: true

--- a/common.go
+++ b/common.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -232,7 +231,7 @@ func getCertificate(certConfig string) ([]byte, error) {
 
 // Read content from file
 func readFromFile(filePath string) ([]byte, error) {
-	dataBytes, err := ioutil.ReadFile(filePath)
+	dataBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from file `%s`: `%v`", filePath, err)
 	}
@@ -308,13 +307,13 @@ func loadServerCertAndKey(certConfig, keyConfig, keyPassConfig string) ([]tls.Ce
 	}
 
 	// Check and Decrypt the the Key Block using passphrase
-	if x509.IsEncryptedPEMBlock(keyBlock) {
+	if x509.IsEncryptedPEMBlock(keyBlock) { // nolint:staticcheck
 		keyFilePassphraseBytes, err := getSecret(keyPassConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get key passphrase: `%s`", err)
 		}
 
-		decryptedDERBytes, err := x509.DecryptPEMBlock(keyBlock, keyFilePassphraseBytes)
+		decryptedDERBytes, err := x509.DecryptPEMBlock(keyBlock, keyFilePassphraseBytes) // nolint:staticcheck
 		if err != nil {
 			return nil, fmt.Errorf("failed to decrypt PEM Block: `%s`", err)
 		}

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -155,7 +154,7 @@ func initConfig(configFile string, config *Config) {
 	log.SetLevel(log.DebugLevel)
 
 	log.Infof("Loading configuration file %s", configFile)
-	blob, err := ioutil.ReadFile(configFile)
+	blob, err := os.ReadFile(configFile)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/main.go
+++ b/main.go
@@ -86,7 +86,10 @@ func main() {
 
 			w.Header().Set("WWW-Authenticate", `Basic realm="AEROSPIKE-PROMETHEUS-EXPORTER-REALM"`)
 			w.WriteHeader(401)
-			w.Write([]byte("401 Unauthorized\n"))
+			_, err := w.Write([]byte("401 Unauthorized\n"))
+			if err != nil {
+				log.Warnf("failed to write http response data for /metrics: %s", err.Error())
+			}
 		} else {
 			promhttp.HandlerFor(promReg, promhttp.HandlerOpts{}).ServeHTTP(w, r)
 		}
@@ -94,12 +97,15 @@ func main() {
 
 	// Handle "/health" url
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`OK`))
+		_, err := w.Write([]byte(`OK`))
+		if err != nil {
+			log.Warnf("failed to write http response for /health: %s", err.Error())
+		}
 	})
 
 	// Handle "/" root url
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`<html>
+		_, err := w.Write([]byte(`<html>
 			<head><title>Aerospike Prometheus Exporter</title></head>
 			<body>
 			<h1>Aerospike Prometheus Exporter</h1>
@@ -107,6 +113,9 @@ func main() {
 			</body>
 			</html>
 		`))
+		if err != nil {
+			log.Warnf("failed to write http response for root /: %s", err.Error())
+		}
 	})
 
 	srv := &http.Server{

--- a/observer.go
+++ b/observer.go
@@ -65,8 +65,8 @@ func initAerospikeTLS() *tls.Config {
 		RootCAs:                  serverPool,
 		InsecureSkipVerify:       false,
 		PreferServerCipherSuites: true,
+		NameToCertificate:        nil,
 	}
-	tlsConfig.BuildNameToCertificate()
 
 	return tlsConfig
 }


### PR DESCRIPTION
[OM-66]

[OM-66]: https://aerospike.atlassian.net/browse/OM-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

- This PR adds golang linter for exporter
- This PR addresses initial failing checks
- This PR creates a github action to run the linter on every PR against `dev` and `main` branch.