### PR TITLE
OM-41 default lat-long to ape.toml

### DIFF
--- a/ape.toml
+++ b/ape.toml
@@ -27,7 +27,7 @@ root_ca = ""
 key_file_passphrase = ""
 
 # labels to add to the prometheus metrics for e.g. labels={zone="asia-south1-a", platform="google compute engine"}
-labels = {}
+labels = {latitude="0",longitude="0"}
 
 bind = ":9145"
 


### PR DESCRIPTION
adds default lat/long to our toml file.