### PR TITLE
OM77 - long_queries_active

### DIFF
--- a/watcher_node_stats.go
+++ b/watcher_node_stats.go
@@ -68,7 +68,8 @@ var statsRawMetrics = map[string]metricType{
 	"batch_index_created_buffers":           mtGauge,
 	"batch_index_destroyed_buffers":         mtCounter,
 	"scans_active":                          mtGauge,
-	"queries_active":                        mtGauge,
+	"queries_active":                        mtGauge, // deprecated
+	"long_queries_active":                   mtGauge,
 	"query_short_running":                   mtCounter,
 	"query_long_running":                    mtCounter,
 	"sindex_ucgarbage_found":                mtCounter,


### PR DESCRIPTION
queries_active is deprecated and replaced with long_queries_active

modified node-stats to export long-queries-active also.

NOTE: this may not be required, if server-agnostic enhancement is implemented