### PR TITLE
Om72

### DIFF
--- a/.github/workflows/build_release_artifacts.yaml
+++ b/.github/workflows/build_release_artifacts.yaml
@@ -59,12 +59,15 @@ jobs:
     - name: make package-linux-amd64
       run: make package-linux-amd64
 
-    - name: make fips-deb 
-      run: make fips-deb
+    - name: gzip tar files
+      run: |
+         cd pkg/target   
+         ls -lrt *.tar
+         echo "GZipping tar files"
+         gzip aerospike-prometheus-exporter*.tar 
+         echo "gzipped files"
+         ls -lrt *.gz
 
-    - name: make fips-rpm
-      run: make fips-rpm
-      
     - name: Upload Release Asset
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +80,7 @@ jobs:
          
          for file in $files; do
            echo "uploading file === $file"
+           # TODO: move this to gh instead of hub
            hub release edit -a $file -m "$RELEASE_NAME $TAG_NAME" "$TAG_NAME"
          done
-
-         hub release edit -a aerospike-prometheus-exporter -m "$RELEASE_NAME $TAG_NAME"  "$TAG_NAME"
+         

--- a/.github/workflows/fips_release_artifact.yml
+++ b/.github/workflows/fips_release_artifact.yml
@@ -2,7 +2,8 @@ name: manual_continuous_deploy
 
 on:
  push:
-   tags: FR*
+  branches:
+    - OM72
 #    workflow_dispatch:
 #      inputs:
 #         release_tag_info:

--- a/.github/workflows/fips_release_artifact.yml
+++ b/.github/workflows/fips_release_artifact.yml
@@ -1,18 +1,15 @@
 name: manual_continuous_deploy
 
 on:
- push:
-  branches:
-    - OM72
-#    workflow_dispatch:
-#      inputs:
-#         release_tag_info:
-#           description: enter release tag number
-#           default: v1.0.0
-#           required: true
+  workflow_dispatch:
+     inputs:
+        release_tag_info:
+          description: enter release tag number
+          default: v1.0.0
+          required: true
 jobs:
 
-  deploy_image:
+  create_fips_binaries:
     runs-on: self-hosted
     steps:
     
@@ -84,6 +81,6 @@ jobs:
          echo
          echo "STARTING: Uploading fips-federal binary:"${{ env.FIPS_EXPORTER_RPM_FILENAME }}
          
-         gh release upload ${{ env.UPLOAD_TAG }} ${{ env.FIPS_EXPORTER_RPM_FILENAME }}
+         gh release upload ${{ github.event.inputs.release_tag_info }} ${{ env.FIPS_EXPORTER_RPM_FILENAME }}
          echo "COMPLETED: Uploading fips-federal binary:".${{env.FIPS_EXPORTER_RPM_FILENAME }}
          


### PR DESCRIPTION
bug fixes - tar artefacts will be gzipped and aerospike-prometheus-exporter binary will not be released as stand-alone
tips build can run in a self-hosted runner