### PR TITLE
sit-nov-testing : fixed github actions

### DIFF
--- a/.github/workflows/build_release_artifacts.yaml
+++ b/.github/workflows/build_release_artifacts.yaml
@@ -59,15 +59,21 @@ jobs:
     - name: make package-linux-amd64
       run: make package-linux-amd64
 
-    - name: gzip tar files
-      run: |
-         cd pkg/target   
-         ls -lrt *.tar
-         echo "GZipping tar files"
-         gzip aerospike-prometheus-exporter*.tar 
-         echo "gzipped files"
-         ls -lrt *.gz
+    # - name: gzip tar files
+    #   run: |
+    #      cd pkg/target   
+    #      ls -lrt *.tar
+    #      echo "GZipping tar files"
+    #      gzip aerospike-prometheus-exporter*.tar 
+    #      echo "gzipped files"
+    #      ls -lrt *.gz
 
+    - name: install hub utility (as workaround)
+      run: |
+          sudo apt update && sudo apt install -y git wget
+          url="$(sudo wget -qO- https://api.github.com/repos/github/hub/releases/latest | tr '"' '\n' | grep '.*/download/.*/hub-linux-amd64-.*.tgz')"
+          sudo wget -qO- "$url" | sudo tar -xzvf- -C /usr/bin --strip-components=2 --wildcards "*/bin/hub"
+        
     - name: Upload Release Asset
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
missed checkin of this file, includes 2 fixes
1. commenting of tar/gzip job as it is taken care of during packaging
2. installing hub package as it is not available by default in ubunut 20.04 anymore as per (https://github.com/actions/runner-images/issues/8362)