### PR TITLE
Om86

### DIFF
--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -60,6 +60,18 @@ func (lw *LatencyWatcher) refresh(o *Observer, infoKeys []string, rawMetrics map
 		}
 	}
 
+	// loop all the latency infokeys
+	for ik := range infoKeys {
+		parseSingleLatenciesKey(infoKeys[ik], rawMetrics, allowedLatenciesList, blockedLatenciessList, ch)
+	}
+
+	return nil
+}
+
+func parseSingleLatenciesKey(singleLatencyKey string, rawMetrics map[string]string,
+	allowedLatenciesList map[string]struct{},
+	blockedLatenciessList map[string]struct{}, ch chan<- prometheus.Metric) error {
+
 	var latencyStats map[string]StatsMap
 
 	if rawMetrics["latencies:"] != "" {

--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -75,7 +75,7 @@ func parseSingleLatenciesKey(singleLatencyKey string, rawMetrics map[string]stri
 	var latencyStats map[string]StatsMap
 
 	if rawMetrics["latencies:"] != "" {
-		latencyStats = parseLatencyInfo(rawMetrics["latencies:"], int(config.Aerospike.LatencyBucketsCount))
+		latencyStats = parseLatencyInfo(rawMetrics[singleLatencyKey], int(config.Aerospike.LatencyBucketsCount))
 	} else {
 		latencyStats = parseLatencyInfoLegacy(rawMetrics["latency:"], int(config.Aerospike.LatencyBucketsCount))
 	}

--- a/watcher_namespaces.go
+++ b/watcher_namespaces.go
@@ -210,6 +210,16 @@ func (nw *NamespaceWatcher) refreshNamespaceStats(singleInfoKey string, infoKeys
 			// push to prom-channel
 			pushToPrometheus(asMetric, pv, labels, labelValues, ch)
 		}
+
+		// below code section is to ensure ns+latencies combination is handled during LatencyWatcher
+		//
+		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
+		if canConsiderLatencyCommand(stat) {
+			LatencyBenchmarks[nsName+"-"+stat] = pv
+		}
+		// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
+		LatencyBenchmarks[nsName+"-re-repl"] = 1
+
 	}
 
 }

--- a/watcher_node_stats.go
+++ b/watcher_node_stats.go
@@ -75,5 +75,10 @@ func (sw *StatsWatcher) handleRefresh(o *Observer, nodeRawMetrics string, cluste
 
 		pushToPrometheus(asMetric, pv, labels, labelsValues, ch)
 
+		// check and if latency benchmarks stat, is it enabled (bool true==1 and false==0 after conversion)
+		if canConsiderLatencyCommand(stat) {
+			LatencyBenchmarks["service-"+stat] = pv
+		}
+
 	}
 }


### PR DESCRIPTION
support for micro benchmarks
issue micro-benchmark commands during latency-watcher passtwo keys
namespace-watcher and node-watcher add respective namespace and service benchmark flags which are later consumed by latency-watcher