### PR TITLE
Om86

### DIFF
--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -152,7 +151,6 @@ func (lw *LatencyWatcher) getLatenciesCommands(rawMetrics map[string]string) []s
 		}
 
 		commands = append(commands, histCommand)
-		fmt.Println(" asinfo -h $1 -v ", histCommand)
 	}
 
 	log.Tracef("latency-passtwokeys:%s", commands)

--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -60,6 +60,18 @@ func (lw *LatencyWatcher) refresh(o *Observer, infoKeys []string, rawMetrics map
 		}
 	}
 
+	// loop all the latency infokeys
+	for ik := range infoKeys {
+		parseSingleLatenciesKey(infoKeys[ik], rawMetrics, allowedLatenciesList, blockedLatenciessList, ch)
+	}
+
+	return nil
+}
+
+func parseSingleLatenciesKey(singleLatencyKey string, rawMetrics map[string]string,
+	allowedLatenciesList map[string]struct{},
+	blockedLatenciessList map[string]struct{}, ch chan<- prometheus.Metric) error {
+
 	var latencyStats map[string]StatsMap
 
 	if rawMetrics["latencies:"] != "" {

--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -62,7 +62,10 @@ func (lw *LatencyWatcher) refresh(o *Observer, infoKeys []string, rawMetrics map
 
 	// loop all the latency infokeys
 	for ik := range infoKeys {
-		parseSingleLatenciesKey(infoKeys[ik], rawMetrics, allowedLatenciesList, blockedLatenciessList, ch)
+		err := parseSingleLatenciesKey(infoKeys[ik], rawMetrics, allowedLatenciesList, blockedLatenciessList, ch)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -61,8 +61,8 @@ func (lw *LatencyWatcher) refresh(o *Observer, infoKeys []string, rawMetrics map
 	}
 
 	// loop all the latency infokeys
-	for ik := range infoKeys {
-		err := parseSingleLatenciesKey(infoKeys[ik], rawMetrics, allowedLatenciesList, blockedLatenciessList, ch)
+	for _, infoKey := range infoKeys {
+		err := parseSingleLatenciesKey(infoKey, rawMetrics, allowedLatenciesList, blockedLatenciessList, ch)
 		if err != nil {
 			return err
 		}
@@ -130,10 +130,7 @@ func isStatLatencyHistRelated(stat string) bool {
 func (lw *LatencyWatcher) getLatenciesCommands(rawMetrics map[string]string) []string {
 	var commands = []string{"latencies:"}
 
-	// below latency-command are added to the auto-enabled list, i.e. latencies: command
-	// re-repl is auto-enabled, but not coming as part of latencies: list, hence we are adding it explicitly
-	//
-	// Hashmap content format := namespace-<histogram-key> = <0/1>
+	// Hashmap content format := namespace-<histogram-key> = <histogram-key>
 	for latencyHistName := range LatencyBenchmarks {
 		histTokens := strings.Split(latencyHistName, "-")
 

--- a/watcher_latency.go
+++ b/watcher_latency.go
@@ -75,7 +75,7 @@ func parseSingleLatenciesKey(singleLatencyKey string, rawMetrics map[string]stri
 	var latencyStats map[string]StatsMap
 
 	if rawMetrics["latencies:"] != "" {
-		latencyStats = parseLatencyInfo(rawMetrics["latencies:"], int(config.Aerospike.LatencyBucketsCount))
+		latencyStats = parseLatencyInfo(rawMetrics[singleLatencyKey], int(config.Aerospike.LatencyBucketsCount))
 	} else {
 		latencyStats = parseLatencyInfoLegacy(rawMetrics["latency:"], int(config.Aerospike.LatencyBucketsCount))
 	}

--- a/watcher_namespaces.go
+++ b/watcher_namespaces.go
@@ -219,10 +219,10 @@ func (nw *NamespaceWatcher) refreshNamespaceStats(singleInfoKey string, infoKeys
 				LatencyBenchmarks[nsName+"-"+stat] = stat
 			}
 		}
-		// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
-		LatencyBenchmarks[nsName+"-latency-hist-re-repl"] = "{" + nsName + "}-re-repl"
 
 	}
+	// // append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
+	// LatencyBenchmarks[nsName+"-latency-hist-re-repl"] = "{" + nsName + "}-re-repl"
 
 }
 

--- a/watcher_namespaces.go
+++ b/watcher_namespaces.go
@@ -177,8 +177,6 @@ func (nw *NamespaceWatcher) refreshNamespaceStats(singleInfoKey string, infoKeys
 		sindexType := stats[SINDEX_TYPE]
 		storageEngine := stats[STORAGE_ENGINE]
 
-		// fmt.Println(" storageEngine: ", storageEngine)
-
 		// if stat is index-type or sindex-type , append addl label
 		if strings.HasPrefix(deviceType, INDEX_TYPE) && len(indexType) > 0 {
 			labels = append(labels, METRIC_LABEL_INDEX)

--- a/watcher_namespaces.go
+++ b/watcher_namespaces.go
@@ -210,6 +210,16 @@ func (nw *NamespaceWatcher) refreshNamespaceStats(singleInfoKey string, infoKeys
 			// push to prom-channel
 			pushToPrometheus(asMetric, pv, labels, labelValues, ch)
 		}
+
+		// below code section is to ensure ns+latencies combination is handled during LatencyWatcher
+		//
+		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
+		if canConsiderLatencyCommand(stat) {
+			LatencyBenchmarks[nsName+"-"+stat] = pv
+		}
+		// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
+		LatencyBenchmarks[nsName+"-re-repl"] = 1
+
 	}
 
 }

--- a/watcher_namespaces.go
+++ b/watcher_namespaces.go
@@ -212,8 +212,12 @@ func (nw *NamespaceWatcher) refreshNamespaceStats(singleInfoKey string, infoKeys
 		// below code section is to ensure ns+latencies combination is handled during LatencyWatcher
 		//
 		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
-		if isStatLatencyHistRelated(stat) && pv == 1 {
-			LatencyBenchmarks[nsName+"-"+stat] = stat
+		if isStatLatencyHistRelated(stat) {
+			delete(LatencyBenchmarks, nsName+"-"+stat)
+
+			if pv == 1 {
+				LatencyBenchmarks[nsName+"-"+stat] = stat
+			}
 		}
 		// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
 		LatencyBenchmarks[nsName+"-latency-hist-re-repl"] = "{" + nsName + "}-re-repl"

--- a/watcher_namespaces.go
+++ b/watcher_namespaces.go
@@ -214,11 +214,11 @@ func (nw *NamespaceWatcher) refreshNamespaceStats(singleInfoKey string, infoKeys
 		// below code section is to ensure ns+latencies combination is handled during LatencyWatcher
 		//
 		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
-		if canConsiderLatencyCommand(stat) {
-			LatencyBenchmarks[nsName+"-"+stat] = pv
+		if isStatLatencyHistRelated(stat) && pv == 1 {
+			LatencyBenchmarks[nsName+"-"+stat] = stat
 		}
 		// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
-		LatencyBenchmarks[nsName+"-re-repl"] = 1
+		LatencyBenchmarks[nsName+"-latency-hist-re-repl"] = "{" + nsName + "}-re-repl"
 
 	}
 

--- a/watcher_node_stats.go
+++ b/watcher_node_stats.go
@@ -75,5 +75,10 @@ func (sw *StatsWatcher) handleRefresh(o *Observer, nodeRawMetrics string, cluste
 
 		pushToPrometheus(asMetric, pv, labels, labelsValues, ch)
 
+		// check and if latency benchmarks stat, is it enabled (bool true==1 and false==0 after conversion)
+		if canConsiderLatencyCommand(stat) {
+			LatencyBenchmarks["service-"+stat] = pv
+		}
+
 	}
 }

--- a/watcher_node_stats.go
+++ b/watcher_node_stats.go
@@ -76,8 +76,13 @@ func (sw *StatsWatcher) handleRefresh(o *Observer, nodeRawMetrics string, cluste
 		pushToPrometheus(asMetric, pv, labels, labelsValues, ch)
 
 		// check and if latency benchmarks stat, is it enabled (bool true==1 and false==0 after conversion)
-		if isStatLatencyHistRelated(stat) && pv == 1 {
-			LatencyBenchmarks["service-"+stat] = stat
+		if isStatLatencyHistRelated(stat) {
+			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
+			delete(LatencyBenchmarks, "service-"+stat)
+
+			if pv == 1 {
+				LatencyBenchmarks["service-"+stat] = stat
+			}
 		}
 
 	}

--- a/watcher_node_stats.go
+++ b/watcher_node_stats.go
@@ -76,8 +76,8 @@ func (sw *StatsWatcher) handleRefresh(o *Observer, nodeRawMetrics string, cluste
 		pushToPrometheus(asMetric, pv, labels, labelsValues, ch)
 
 		// check and if latency benchmarks stat, is it enabled (bool true==1 and false==0 after conversion)
-		if canConsiderLatencyCommand(stat) {
-			LatencyBenchmarks["service-"+stat] = pv
+		if isStatLatencyHistRelated(stat) && pv == 1 {
+			LatencyBenchmarks["service-"+stat] = stat
 		}
 
 	}


### PR DESCRIPTION
support for micro benchmarks
issue micro-benchmark commands during latency-watcher passtwo keys
namespace-watcher and node-watcher add respective namespace and service benchmark flags which are later consumed by latency-watcher