### PR TITLE
allow aerospike prometheus exporter to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ COPY ape.toml.template /etc/aerospike-prometheus-exporter/ape.toml.template
 COPY gauge_stats_list.toml /etc/aerospike-prometheus-exporter/gauge_stats_list.toml
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+RUN chmod -R a+rwX /etc/aerospike-prometheus-exporter
+
 RUN apk add gettext libintl \
 	&& chmod +x /docker-entrypoint.sh
 


### PR DESCRIPTION
Since the prometheus exporter leverages various configuration files under `/etc/aerospike-prometheus-exporter` directory by default, the pull request updates the permission to allow running aerospike prometheus exporter container run as non-root user. This allows us to host this exporter under restricted environment where pods needs to be started as non-root user.