### PR TITLE
OM173 - bct issue, old exporter config file fails

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -176,6 +176,10 @@ func (c *Config) ValidateAndUpdate(md toml.MetaData) {
 		c.Agent.Otel.OtelPushInterval = 15
 	}
 
+	if !md.IsDefined("Agent", "PROMETHEUS") {
+		log.Infof("Defaulting to Prometheus Exporting mode")
+		c.Agent.PrometheusEnabled = true
+	}
 }
 
 func (c *Config) FetchCloudInfo(md toml.MetaData) {


### PR DESCRIPTION
added a check if old config file is used without prometheus config key, to auto fall back to prometheus enabled mode