### PR TITLE
Om 189

### DIFF
--- a/internal/pkg/commons/constants.go
+++ b/internal/pkg/commons/constants.go
@@ -30,7 +30,7 @@ const (
 	METRIC_LABEL_PORT                 = "port"
 	METRIC_LABEL_NODE_ID              = "node_id"
 	METRIC_LABEL_TLS_NAME             = "tls_name"
-	METRIC_LABEL_ENDPOINT_LIST_PREFIX = "endpoints_"
+	METRIC_LABEL_ENDPOINT_LIST_PREFIX = "peers_"
 )
 
 // constants used to identify type of metrics

--- a/internal/pkg/commons/constants.go
+++ b/internal/pkg/commons/constants.go
@@ -26,11 +26,11 @@ const (
 	METRIC_LABEL_STORAGE_ENGINE = "storage_engine"
 	METRIC_LABEL_USER           = "user"
 
-	METRIC_LABEL_GEN           = "generation"
-	METRIC_LABEL_PORT          = "ort"
-	METRIC_LABEL_NODE_ID       = "node_id"
-	METRIC_LABEL_TLS_NAME      = "tls_name"
-	METRIC_LABEL_ENDPOINT_LIST = "endpoint_list"
+	METRIC_LABEL_GEN                  = "generation"
+	METRIC_LABEL_PORT                 = "port"
+	METRIC_LABEL_NODE_ID              = "node_id"
+	METRIC_LABEL_TLS_NAME             = "tls_name"
+	METRIC_LABEL_ENDPOINT_LIST_PREFIX = "endpoints_"
 )
 
 // constants used to identify type of metrics

--- a/internal/pkg/commons/constants.go
+++ b/internal/pkg/commons/constants.go
@@ -3,6 +3,7 @@ package commons
 import "github.com/prometheus/procfs"
 
 const (
+	CTX_GLOBAL     ContextType = "global"
 	CTX_USERS      ContextType = "users"
 	CTX_NAMESPACE  ContextType = "namespace"
 	CTX_NODE_STATS ContextType = "node_stats"
@@ -24,6 +25,12 @@ const (
 	METRIC_LABEL_SINDEX         = "sindex"
 	METRIC_LABEL_STORAGE_ENGINE = "storage_engine"
 	METRIC_LABEL_USER           = "user"
+
+	METRIC_LABEL_GEN           = "generation"
+	METRIC_LABEL_PORT          = "ort"
+	METRIC_LABEL_NODE_ID       = "node_id"
+	METRIC_LABEL_TLS_NAME      = "tls_name"
+	METRIC_LABEL_ENDPOINT_LIST = "endpoint_list"
 )
 
 // constants used to identify type of metrics

--- a/internal/pkg/statprocessors/sp_globals.go
+++ b/internal/pkg/statprocessors/sp_globals.go
@@ -63,11 +63,15 @@ func parseServerPeersMetrics(rawMetrics map[string]string) ([]AerospikeStat, err
 	fmt.Println("peerNodesData ==> ", peerNodesData)
 	var allMetricsToSend = []AerospikeStat{}
 
-	// 4,3000,[[BB9060011AC4202,,[172.17.0.6]],[BB90F0011AC4202,,[172.17.0.15]]]
+	// 4,3000,[[BB9060011AC4202,,[172.17.0.6,172.17.0.A]],[BB90F0011AC4202,,[172.17.0.15]]]
 	if len(strings.Trim(peerNodesData, " ")) > 0 {
 		peerNodesData = strings.Trim(peerNodesData, " ")
 
 		peersVersionAndPort := peerNodesData[0 : strings.Index(peerNodesData, "[")-1]
+		if len(strings.Trim(peerNodesData, " ")) == 0 {
+			return allMetricsToSend, nil
+		}
+
 		peerNodesData = peerNodesData[strings.Index(peerNodesData, "["):]
 		peerNodesData = peerNodesData[1 : len(peerNodesData)-2]
 

--- a/internal/pkg/statprocessors/sp_globals.go
+++ b/internal/pkg/statprocessors/sp_globals.go
@@ -1,0 +1,114 @@
+package statprocessors
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aerospike/aerospike-prometheus-exporter/internal/pkg/commons"
+	log "github.com/sirupsen/logrus"
+)
+
+type GlobalStatsProcessor struct {
+	globalMetrics map[string]AerospikeStat
+}
+
+func (sw *GlobalStatsProcessor) PassOneKeys() []string {
+	log.Tracef("globals-passtwokeys:nil")
+
+	return nil
+
+}
+
+func (sw *GlobalStatsProcessor) PassTwoKeys(rawMetrics map[string]string) []string {
+	var cmds []string
+	// cmds = append(cmds, "build")
+	if canFetchServerPeers() {
+		cmds = append(cmds, Infokey_PeersCommand)
+	}
+	log.Tracef("globals-passonekeys:%s", cmds)
+
+	// fmt.Println("\t *** GlobalStatsProcessor ", cmds)
+
+	return cmds
+}
+
+func (sw *GlobalStatsProcessor) Refresh(infoKeys []string, rawMetrics map[string]string) ([]AerospikeStat, error) {
+	// parse peers-command output
+	allMetricsToSend, err := parseServerPeersMetrics(rawMetrics)
+
+	return allMetricsToSend, err
+}
+
+// utility will check if we can fetch the node-peers
+func canFetchServerPeers() bool {
+
+	//TODO: write logic
+
+	// difference between current-time and last-fetch, if its > defined-value, then true
+	timeDiff := time.Since(serverPeersPreviousFetchTime)
+
+	// if index-type=false or sindex-type=flash is returned by server
+	//    and every N seconds - where N is mentioned "indexPressureFetchIntervalInSeconds"
+	isTimeOk := timeDiff.Minutes() >= serverPeersFetchInterval
+
+	return isTimeOk
+
+}
+
+func parseServerPeersMetrics(rawMetrics map[string]string) ([]AerospikeStat, error) {
+	peerNodesData := rawMetrics[Infokey_PeersCommand]
+
+	fmt.Println("peerNodesData ==> ", peerNodesData)
+	var allMetricsToSend = []AerospikeStat{}
+
+	// 4,3000,[[BB9060011AC4202,,[172.17.0.6]],[BB90F0011AC4202,,[172.17.0.15]]]
+	if len(strings.Trim(peerNodesData, " ")) > 0 {
+		peerNodesData = strings.Trim(peerNodesData, " ")
+
+		peersVersionAndPort := peerNodesData[0 : strings.Index(peerNodesData, "[")-1]
+		peerNodesData = peerNodesData[strings.Index(peerNodesData, "["):]
+		peerNodesData = peerNodesData[1 : len(peerNodesData)-2]
+
+		peersGenVersion := strings.Split(peersVersionAndPort, ",")[0]
+		peersPort := strings.Split(peersVersionAndPort, ",")[1]
+
+		peerNodeInfos := strings.Split(peerNodesData, "],")
+
+		labels := []string{commons.METRIC_LABEL_CLUSTER_NAME, commons.METRIC_LABEL_SERVICE,
+			commons.METRIC_LABEL_GEN, commons.METRIC_LABEL_PORT,
+			commons.METRIC_LABEL_NODE_ID, commons.METRIC_LABEL_TLS_NAME, commons.METRIC_LABEL_ENDPOINT_LIST}
+
+		var nodeId, peerTcp, peerIps string
+		for _, ele := range peerNodeInfos {
+			peerInfo := strings.Split(ele[1:len(ele)], ",")
+
+			nodeId = peerInfo[0]
+			peerTcp = peerInfo[1]
+			if len(strings.Trim(peerInfo[1], " ")) == 0 {
+				peerTcp = "std"
+			}
+
+			localPeerIps := peerInfo[2][1 : len(peerInfo[2])-1]
+
+			// get only 1st IP address
+			localPeerIps = strings.Split(localPeerIps, ",")[0]
+
+			peerIps = peerIps + localPeerIps + ","
+
+		}
+
+		// remove last comma
+		peerIps = peerIps[0 : len(peerIps)-1]
+		labelValues := []string{ClusterName, Service, peersGenVersion, peersPort, nodeId, peerTcp, peerIps}
+		asMetric := NewAerospikeStat(commons.CTX_GLOBAL, "peers_details", true)
+
+		asMetric.updateValues(1, labels, labelValues)
+		allMetricsToSend = append(allMetricsToSend, asMetric)
+
+		fmt.Println(peersGenVersion, peersPort, nodeId, peerTcp, peerIps)
+
+	}
+
+	return allMetricsToSend, nil
+}

--- a/internal/pkg/statprocessors/sp_globals.go
+++ b/internal/pkg/statprocessors/sp_globals.go
@@ -13,7 +13,7 @@ var (
 	MAX_PEERS_PER_LABEL = 32
 
 	// time interval to fetch index-pressure
-	serverPeersFetchInterval = 1.0
+	serverPeersFetchInterval = 0.1
 
 	// Time when  Server Peers were last-fetched
 	serverPeersPreviousFetchTime = time.Now()
@@ -71,12 +71,12 @@ func parseServerPeersMetrics(rawMetrics map[string]string) ([]AerospikeStat, err
 		peerNodesData = strings.Trim(peerNodesData, " ")
 
 		peersVersionAndPort := peerNodesData[0 : strings.Index(peerNodesData, "[")-1]
-		// If no nodes, skip
-		if len(strings.Trim(peerNodesData, " ")) == 0 {
-			return allMetricsToSend, nil
-		}
 
 		peerNodesData = peerNodesData[strings.Index(peerNodesData, "["):]
+		// If no nodes, skip
+		if peerNodesData == "[]" || len(strings.Trim(peerNodesData, " ")) == 0 {
+			return allMetricsToSend, nil
+		}
 		peerNodesData = peerNodesData[1 : len(peerNodesData)-2]
 
 		peersGenVersion := strings.Split(peersVersionAndPort, ",")[0]

--- a/internal/pkg/statprocessors/sp_node_stats.go
+++ b/internal/pkg/statprocessors/sp_node_stats.go
@@ -61,6 +61,9 @@ func (sw *NodeStatsProcessor) Refresh(infoKeys []string, rawMetrics map[string]s
 func (sw *NodeStatsProcessor) handleRefresh(nodeRawMetrics string) []AerospikeStat {
 
 	stats := commons.ParseStats(nodeRawMetrics, ";")
+	if len(NodeId) == 0 {
+		NodeId = stats["node-id"]
+	}
 
 	var refreshMetricsToSend = []AerospikeStat{}
 

--- a/internal/pkg/statprocessors/statsprocessor.go
+++ b/internal/pkg/statprocessors/statsprocessor.go
@@ -3,6 +3,7 @@ package statprocessors
 var (
 	// Node service endpoint, cluster name and build version
 	Service, ClusterName, Build string
+	PeersInfo                   string
 )
 
 var LatencyBenchmarks = make(map[string]string)
@@ -15,6 +16,7 @@ type StatProcessor interface {
 
 // stat-processors are created only once per process
 var statprocessors = []StatProcessor{
+	&GlobalStatsProcessor{},
 	&NamespaceStatsProcessor{},
 	&NodeStatsProcessor{},
 	&SetsStatsProcessor{},

--- a/internal/pkg/statprocessors/statsprocessor.go
+++ b/internal/pkg/statprocessors/statsprocessor.go
@@ -3,7 +3,7 @@ package statprocessors
 var (
 	// Node service endpoint, cluster name and build version
 	Service, ClusterName, Build string
-	PeersInfo                   string
+	PeersInfo, NodeId           string
 )
 
 var LatencyBenchmarks = make(map[string]string)

--- a/internal/pkg/statprocessors/statsrefresh.go
+++ b/internal/pkg/statprocessors/statsrefresh.go
@@ -94,6 +94,9 @@ func Refresh() ([]AerospikeStat, error) {
 		Service = config.Cfg.Agent.KubernetesPodName
 	}
 
+	// parse peers-command output
+	parseServerPeersMetrics(rawMetrics)
+
 	// sanitize the utf8 strings before sending them to watchers
 	for k, v := range rawMetrics {
 		rawMetrics[k] = commons.SanitizeUTF8(v)
@@ -114,7 +117,7 @@ func Refresh() ([]AerospikeStat, error) {
 	return allMetricsToSend, nil
 }
 
-// utility will check if the given value is flash and sets the flag
+// utility will check if we can fetch the node-peers
 func canFetchServerPeers() bool {
 
 	//TODO: write logic
@@ -128,4 +131,8 @@ func canFetchServerPeers() bool {
 
 	return isTimeOk
 
+}
+
+func parseServerPeersMetrics(rawMetrics map[string]string) {
+	fmt.Println(rawMetrics[peersCommand])
 }

--- a/internal/pkg/statprocessors/statsrefresh.go
+++ b/internal/pkg/statprocessors/statsrefresh.go
@@ -1,21 +1,10 @@
 package statprocessors
 
 import (
-	"time"
-
 	commons "github.com/aerospike/aerospike-prometheus-exporter/internal/pkg/commons"
 	"github.com/aerospike/aerospike-prometheus-exporter/internal/pkg/config"
 	"github.com/aerospike/aerospike-prometheus-exporter/internal/pkg/dataprovider"
 	log "github.com/sirupsen/logrus"
-)
-
-var (
-
-	// time interval to fetch index-pressure
-	serverPeersFetchInterval = 0.5
-
-	// Time when  Server Peers were last-fetched
-	serverPeersPreviousFetchTime = time.Now()
 )
 
 // public and utility functions

--- a/internal/pkg/statprocessors/utils.go
+++ b/internal/pkg/statprocessors/utils.go
@@ -15,6 +15,9 @@ import (
 const (
 	INFOKEY_SERVICE_CLEAR_STD = "service-clear-std"
 	INFOKEY_SERVICE_TLS_STD   = "service-tls-std"
+
+	PEERS_CLEAR_STD = "peers-clear-std"
+	PEERS_TLS_STD   = "peers-tls-std"
 )
 
 // Default info commands
@@ -22,6 +25,8 @@ var (
 	Infokey_ClusterName = "cluster-name"
 	Infokey_Service     = INFOKEY_SERVICE_CLEAR_STD
 	Infokey_Build       = "build"
+
+	peersCommand = PEERS_CLEAR_STD
 )
 
 var (

--- a/internal/pkg/statprocessors/utils.go
+++ b/internal/pkg/statprocessors/utils.go
@@ -26,7 +26,7 @@ var (
 	Infokey_Service     = INFOKEY_SERVICE_CLEAR_STD
 	Infokey_Build       = "build"
 
-	peersCommand = PEERS_CLEAR_STD
+	Infokey_PeersCommand = PEERS_CLEAR_STD
 )
 
 var (


### PR DESCRIPTION
enhanced exporter to
- read peer-node information of the server by sending "peers-clear-std" or "peers-tls-std"
- send the peer-nodes as label with each label having 32 node-ids maximum, so a maximum of 8 labels will be send in the new metric ( supporting 256 node-ids )