### PR TITLE
OM-206 - support pem, certificate, key files with LR or CRLF

### DIFF
--- a/internal/pkg/commons/utils.go
+++ b/internal/pkg/commons/utils.go
@@ -281,6 +281,7 @@ func readFromFile(filePath string) ([]byte, error) {
 	}
 
 	data := bytes.TrimSuffix(dataBytes, []byte("\n"))
+	data = bytes.ReplaceAll(data, []byte("\r"), []byte(""))
 
 	return data, nil
 }


### PR DESCRIPTION
nullified all \r in read pem , cert, key files