### PR TITLE
OM-209 - latencies command is not working

### DIFF
--- a/internal/pkg/statprocessors/sp_latency.go
+++ b/internal/pkg/statprocessors/sp_latency.go
@@ -1,6 +1,7 @@
 package statprocessors
 
 import (
+	"fmt"
 	"strings"
 
 	commons "github.com/aerospike/aerospike-prometheus-exporter/internal/pkg/commons"
@@ -64,6 +65,8 @@ func (lw *LatencyStatsProcessor) getLatenciesCommands(rawMetrics map[string]stri
 			if strings.Contains(stat, "hist-") {
 				stat = strings.ReplaceAll(stat, "hist-", "")
 			}
+
+			fmt.Println("\t ** histCommand - asinfo -h 172.17.0.5 -v ", histCommand)
 
 			histCommand = histCommand + stat
 			commands = append(commands, histCommand)

--- a/internal/pkg/statprocessors/sp_latency.go
+++ b/internal/pkg/statprocessors/sp_latency.go
@@ -49,24 +49,19 @@ func (lw *LatencyStatsProcessor) getLatenciesCommands(rawMetrics map[string]stri
 
 	// below latency-command are added to the auto-enabled list, i.e. latencies: command
 	// re-repl is auto-enabled, but not coming as part of latencies: list, hence we are adding it explicitly
-	//
-	// Hashmap content format := namespace_enable_<latency>=latency-command
-	// some latencies are configured and fetch for each namespace.
-	// command will be like latencies:hist={NAMESPACE}-proxy / latencies:hist={NAMESPACE}-benchmarks-read
-	//
-	for _, latencyCommand := range NamespaceLatencyBenchmarks {
-		// ns-enable-benchmarks-ops-sub or ns-enable-hist-proxy
-		histCommand := "latencies:hist=" + latencyCommand
-		log.Tracef("namespace histCommand - asinfo <-h IP> -v %s", histCommand)
-		commands = append(commands, histCommand)
+	// command will be like
+	//      latencies:hist={NAMESPACE}-proxy / latencies:hist={NAMESPACE}-benchmarks-read
+	//      latencies:hist=info
+
+	for nsName := range NamespaceLatencyBenchmarks {
+		for _, latencyCommand := range NamespaceLatencyBenchmarks[nsName] {
+			histCommand := "latencies:hist=" + latencyCommand
+			commands = append(commands, histCommand)
+		}
 	}
 
-	// some latencies are configured at service level which will come for each node
-	// command will be like latencies:hist=info
-	for _, latencyCommand := range NodeLatencyBenchmarks {
-		// enable-benchmarks-fabric or enable-hist-info
+	for _, latencyCommand := range ServiceLatencyBenchmarks {
 		histCommand := "latencies:hist=" + latencyCommand
-		log.Tracef("node histCommand - asinfo <-h IP>  -v %s", histCommand)
 		commands = append(commands, histCommand)
 	}
 

--- a/internal/pkg/statprocessors/sp_latency.go
+++ b/internal/pkg/statprocessors/sp_latency.go
@@ -52,7 +52,7 @@ func (lw *LatencyStatsProcessor) getLatenciesCommands(rawMetrics map[string]stri
 	//
 	// Hashmap content format := namespace-<histogram-key> = <0/1>
 	for latencyHistName := range LatencyBenchmarks {
-		histTokens := strings.Split(latencyHistName, "-")
+		histTokens := strings.Split(latencyHistName, "~")
 
 		histCommand := "latencies:hist="
 
@@ -70,7 +70,7 @@ func (lw *LatencyStatsProcessor) getLatenciesCommands(rawMetrics map[string]stri
 		commands = append(commands, histCommand)
 	}
 
-	log.Tracef("latency-passtwokeys:%s", commands)
+	log.Tracef("latency-getLatenciesCommands:%s", commands)
 
 	return commands
 }

--- a/internal/pkg/statprocessors/sp_latency.go
+++ b/internal/pkg/statprocessors/sp_latency.go
@@ -51,26 +51,23 @@ func (lw *LatencyStatsProcessor) getLatenciesCommands(rawMetrics map[string]stri
 	// re-repl is auto-enabled, but not coming as part of latencies: list, hence we are adding it explicitly
 	//
 	// Hashmap content format := namespace-<histogram-key> = <0/1>
-	for latencyHistName := range LatencyBenchmarks {
-		nsName := strings.Split(latencyHistName, "~")[0]
-		stat := LatencyBenchmarks[latencyHistName]
+	for nsName, nsLatencies := range NamespaceLatencyBenchmarks {
 
-		histCommand := "latencies:hist="
+		for stat := range nsLatencies {
+			histCommand := "latencies:hist="
 
-		// service-enable-benchmarks-fabric or ns-enable-benchmarks-ops-sub or service-enable-hist-info or service-enable-hist-proxy
-		if nsName != "service" {
+			// service-enable-benchmarks-fabric or ns-enable-benchmarks-ops-sub or service-enable-hist-info or service-enable-hist-proxy
 			histCommand = histCommand + "{" + nsName + "}-"
-		}
-		if strings.Contains(stat, "enable-") {
-			stat = strings.ReplaceAll(stat, "enable-", "")
-		}
-		if strings.Contains(stat, "hist-") {
-			stat = strings.ReplaceAll(stat, "hist-", "")
-		}
+			if strings.Contains(stat, "enable-") {
+				stat = strings.ReplaceAll(stat, "enable-", "")
+			}
+			if strings.Contains(stat, "hist-") {
+				stat = strings.ReplaceAll(stat, "hist-", "")
+			}
 
-		histCommand = histCommand + stat
-
-		commands = append(commands, histCommand)
+			histCommand = histCommand + stat
+			commands = append(commands, histCommand)
+		}
 	}
 
 	log.Tracef("latency-getLatenciesCommands:%s", commands)

--- a/internal/pkg/statprocessors/sp_latency.go
+++ b/internal/pkg/statprocessors/sp_latency.go
@@ -52,20 +52,23 @@ func (lw *LatencyStatsProcessor) getLatenciesCommands(rawMetrics map[string]stri
 	//
 	// Hashmap content format := namespace-<histogram-key> = <0/1>
 	for latencyHistName := range LatencyBenchmarks {
-		histTokens := strings.Split(latencyHistName, "~")
+		nsName := strings.Split(latencyHistName, "~")[0]
+		stat := LatencyBenchmarks[latencyHistName]
 
 		histCommand := "latencies:hist="
 
-		// service-enable-benchmarks-fabric or ns-enable-benchmarks-ops-sub or service-enable-hist-info
-		if histTokens[0] != "service" {
-			histCommand = histCommand + "{" + histTokens[0] + "}-"
+		// service-enable-benchmarks-fabric or ns-enable-benchmarks-ops-sub or service-enable-hist-info or service-enable-hist-proxy
+		if nsName != "service" {
+			histCommand = histCommand + "{" + nsName + "}-"
+		}
+		if strings.Contains(stat, "enable-") {
+			stat = strings.ReplaceAll(stat, "enable-", "")
+		}
+		if strings.Contains(stat, "hist-") {
+			stat = strings.ReplaceAll(stat, "hist-", "")
 		}
 
-		if strings.Contains(latencyHistName, "enable-benchmarks-") {
-			histCommand = histCommand + strings.Join(histTokens[2:], "-")
-		} else {
-			histCommand = histCommand + strings.Join(histTokens[3:], "-")
-		}
+		histCommand = histCommand + stat
 
 		commands = append(commands, histCommand)
 	}

--- a/internal/pkg/statprocessors/sp_namespaces.go
+++ b/internal/pkg/statprocessors/sp_namespaces.go
@@ -233,16 +233,23 @@ func (nw *NamespaceStatsProcessor) refreshNamespaceStats(singleInfoKey string, i
 		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
 		if isStatLatencyHistRelated(stat) {
 			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
-			delete(NamespaceLatencyBenchmarks[nsName], stat)
+			delete(NamespaceLatencyBenchmarks, nsName+"_"+stat)
 
 			if pv == 1 {
-				NamespaceLatencyBenchmarks[nsName][stat] = stat
+				latencyOption := "{" + nsName + "}-" + stat
+				if strings.Contains(latencyOption, "enable-") {
+					latencyOption = strings.ReplaceAll(latencyOption, "enable-", "")
+				}
+				if strings.Contains(latencyOption, "hist-") {
+					latencyOption = strings.ReplaceAll(latencyOption, "hist-", "")
+				}
+				NamespaceLatencyBenchmarks[nsName+"_"+stat] = latencyOption
 			}
 		}
 
 	}
 	// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
-	NamespaceLatencyBenchmarks[nsName]["re-repl"] = "re-repl"
+	NamespaceLatencyBenchmarks[nsName+"_re-repl"] = "{" + nsName + "}-" + "re-repl"
 
 	return nsMetricsToSend
 }

--- a/internal/pkg/statprocessors/sp_namespaces.go
+++ b/internal/pkg/statprocessors/sp_namespaces.go
@@ -233,16 +233,16 @@ func (nw *NamespaceStatsProcessor) refreshNamespaceStats(singleInfoKey string, i
 		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
 		if isStatLatencyHistRelated(stat) {
 			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
-			delete(LatencyBenchmarks, nsName+"~"+stat)
+			delete(NamespaceLatencyBenchmarks[nsName], stat)
 
 			if pv == 1 {
-				LatencyBenchmarks[nsName+"~"+stat] = stat
+				NamespaceLatencyBenchmarks[nsName][stat] = stat
 			}
 		}
 
 	}
 	// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
-	LatencyBenchmarks[nsName+"~latency-hist-re-repl"] = "re-repl"
+	NamespaceLatencyBenchmarks[nsName]["re-repl"] = "re-repl"
 
 	return nsMetricsToSend
 }

--- a/internal/pkg/statprocessors/sp_namespaces.go
+++ b/internal/pkg/statprocessors/sp_namespaces.go
@@ -239,7 +239,7 @@ func (nw *NamespaceStatsProcessor) refreshNamespaceStats(singleInfoKey string, i
 				if strings.Contains(latencySubcommand, "enable-") {
 					latencySubcommand = strings.ReplaceAll(latencySubcommand, "enable-", "")
 				}
-				// some histogram command has 'hist-' prefix but the latency command does not expect hist- when issue the command
+				// some histogram stats has 'hist-' in the config, but the latency command does not expect hist- when issue the command
 				if strings.Contains(latencySubcommand, "hist-") {
 					latencySubcommand = strings.ReplaceAll(latencySubcommand, "hist-", "")
 				}

--- a/internal/pkg/statprocessors/sp_namespaces.go
+++ b/internal/pkg/statprocessors/sp_namespaces.go
@@ -50,14 +50,17 @@ func (nw *NamespaceStatsProcessor) PassOneKeys() []string {
 
 func (nw *NamespaceStatsProcessor) PassTwoKeys(rawMetrics map[string]string) []string {
 	s := rawMetrics[KEY_NS_METADATA]
-	list := strings.Split(s, ";")
+	nsList := strings.Split(s, ";")
 
 	log.Tracef("namespaces:%s", s)
 
 	var infoKeys []string
-	for _, k := range list {
+	for _, ns := range nsList {
 		// infoKey ==> namespace/test, namespace/bar
-		infoKeys = append(infoKeys, KEY_NS_NAMESPACE+"/"+k)
+		infoKeys = append(infoKeys, KEY_NS_NAMESPACE+"/"+ns)
+		if NamespaceLatencyBenchmarks[ns] == nil {
+			NamespaceLatencyBenchmarks[ns] = make(map[string]string)
+		}
 	}
 
 	if nw.canSendIndexPressureInfoKey() {
@@ -228,28 +231,28 @@ func (nw *NamespaceStatsProcessor) refreshNamespaceStats(singleInfoKey string, i
 			nsMetricsToSend = append(nsMetricsToSend, asMetric)
 		}
 
-		// below code section is to ensure ns+latencies combination is handled during LatencyWatcher
-		//
-		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
+		// below code section is to ensure latencies combination is handled during LatencyWatcher
 		if isStatLatencyHistRelated(stat) {
-			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
-			delete(NamespaceLatencyBenchmarks, nsName+"_"+stat)
-
+			// pv==1 means histogram is enabled
 			if pv == 1 {
-				latencyOption := "{" + nsName + "}-" + stat
-				if strings.Contains(latencyOption, "enable-") {
-					latencyOption = strings.ReplaceAll(latencyOption, "enable-", "")
+				latencySubcommand := "{" + nsName + "}-" + stat
+				if strings.Contains(latencySubcommand, "enable-") {
+					latencySubcommand = strings.ReplaceAll(latencySubcommand, "enable-", "")
 				}
-				if strings.Contains(latencyOption, "hist-") {
-					latencyOption = strings.ReplaceAll(latencyOption, "hist-", "")
+				// some histogram command has 'hist-' prefix but the latency command does not expect hist- when issue the command
+				if strings.Contains(latencySubcommand, "hist-") {
+					latencySubcommand = strings.ReplaceAll(latencySubcommand, "hist-", "")
 				}
-				NamespaceLatencyBenchmarks[nsName+"_"+stat] = latencyOption
+				NamespaceLatencyBenchmarks[nsName][stat] = latencySubcommand
+			} else {
+				// pv==0 means histogram is disabled
+				delete(NamespaceLatencyBenchmarks[nsName], stat)
 			}
 		}
 
 	}
 	// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
-	NamespaceLatencyBenchmarks[nsName+"_re-repl"] = "{" + nsName + "}-" + "re-repl"
+	NamespaceLatencyBenchmarks[nsName]["re-repl"] = "{" + nsName + "}-" + "re-repl"
 
 	return nsMetricsToSend
 }

--- a/internal/pkg/statprocessors/sp_namespaces.go
+++ b/internal/pkg/statprocessors/sp_namespaces.go
@@ -1,7 +1,6 @@
 package statprocessors
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -235,8 +234,6 @@ func (nw *NamespaceStatsProcessor) refreshNamespaceStats(singleInfoKey string, i
 		if isStatLatencyHistRelated(stat) {
 			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
 			delete(LatencyBenchmarks, nsName+"~"+stat)
-
-			fmt.Println("\t ===> ", nsName, " === stat ", stat)
 
 			if pv == 1 {
 				LatencyBenchmarks[nsName+"~"+stat] = stat

--- a/internal/pkg/statprocessors/sp_namespaces.go
+++ b/internal/pkg/statprocessors/sp_namespaces.go
@@ -244,10 +244,10 @@ func (nw *NamespaceStatsProcessor) refreshNamespaceStats(singleInfoKey string, i
 		//
 		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
 		if isStatLatencyHistRelated(stat) {
-			delete(LatencyBenchmarks, nsName+"-"+stat)
+			delete(LatencyBenchmarks, nsName+"~"+stat)
 
 			if pv == 1 {
-				LatencyBenchmarks[nsName+"-"+stat] = stat
+				LatencyBenchmarks[nsName+"~"+stat] = stat
 			}
 		}
 

--- a/internal/pkg/statprocessors/sp_namespaces.go
+++ b/internal/pkg/statprocessors/sp_namespaces.go
@@ -1,6 +1,7 @@
 package statprocessors
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -233,18 +234,9 @@ func (nw *NamespaceStatsProcessor) refreshNamespaceStats(singleInfoKey string, i
 		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
 		if isStatLatencyHistRelated(stat) {
 			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
-			delete(LatencyBenchmarks, nsName+"-"+stat)
-
-			if pv == 1 {
-				LatencyBenchmarks[nsName+"-"+stat] = stat
-			}
-		}
-
-		// below code section is to ensure ns+latencies combination is handled during LatencyWatcher
-		//
-		// check and if latency benchmarks stat - is it enabled (bool true==1 and false==0 after conversion)
-		if isStatLatencyHistRelated(stat) {
 			delete(LatencyBenchmarks, nsName+"~"+stat)
+
+			fmt.Println("\t ===> ", nsName, " === stat ", stat)
 
 			if pv == 1 {
 				LatencyBenchmarks[nsName+"~"+stat] = stat
@@ -253,7 +245,7 @@ func (nw *NamespaceStatsProcessor) refreshNamespaceStats(singleInfoKey string, i
 
 	}
 	// append default re-repl, as this auto-enabled, but not coming as part of latencies, we need this as namespace is available only here
-	LatencyBenchmarks[nsName+"-latency-hist-re-repl"] = "{" + nsName + "}-re-repl"
+	LatencyBenchmarks[nsName+"~latency-hist-re-repl"] = "re-repl"
 
 	return nsMetricsToSend
 }

--- a/internal/pkg/statprocessors/sp_node_stats.go
+++ b/internal/pkg/statprocessors/sp_node_stats.go
@@ -88,10 +88,10 @@ func (sw *NodeStatsProcessor) handleRefresh(nodeRawMetrics string) []AerospikeSt
 		if isStatLatencyHistRelated(stat) {
 
 			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
-			delete(LatencyBenchmarks, "service~"+stat)
+			delete(NodeLatencyBenchmarks, stat)
 
 			if pv == 1 {
-				LatencyBenchmarks["service~"+stat] = stat
+				NodeLatencyBenchmarks[stat] = stat
 			}
 		}
 	}

--- a/internal/pkg/statprocessors/sp_node_stats.go
+++ b/internal/pkg/statprocessors/sp_node_stats.go
@@ -95,7 +95,7 @@ func (sw *NodeStatsProcessor) handleRefresh(nodeRawMetrics string) []AerospikeSt
 				if strings.Contains(latencySubcommand, "enable-") {
 					latencySubcommand = strings.ReplaceAll(latencySubcommand, "enable-", "")
 				}
-				// some histogram command has 'hist-' prefix but the latency command does not expect hist- when issue the command
+				// some histogram stats has 'hist-' in the config, but the latency command does not expect hist- when issue the command
 				if strings.Contains(latencySubcommand, "hist-") {
 					latencySubcommand = strings.ReplaceAll(latencySubcommand, "hist-", "")
 				}

--- a/internal/pkg/statprocessors/sp_node_stats.go
+++ b/internal/pkg/statprocessors/sp_node_stats.go
@@ -88,10 +88,10 @@ func (sw *NodeStatsProcessor) handleRefresh(nodeRawMetrics string) []AerospikeSt
 		if isStatLatencyHistRelated(stat) {
 
 			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
-			delete(LatencyBenchmarks, "service-"+stat)
+			delete(LatencyBenchmarks, "service~"+stat)
 
 			if pv == 1 {
-				LatencyBenchmarks["service-"+stat] = stat
+				LatencyBenchmarks["service~"+stat] = stat
 			}
 		}
 	}

--- a/internal/pkg/statprocessors/sp_node_stats.go
+++ b/internal/pkg/statprocessors/sp_node_stats.go
@@ -89,19 +89,21 @@ func (sw *NodeStatsProcessor) handleRefresh(nodeRawMetrics string) []AerospikeSt
 		// check and if latency benchmarks stat, is it enabled (bool true==1 and false==0 after conversion)
 		if isStatLatencyHistRelated(stat) {
 
-			// remove old value as microbenchmark may get enabled / disable on-the-fly at server so we cannot rely on value
-			delete(NodeLatencyBenchmarks, stat)
-
+			// pv==1 means histogram is enabled
 			if pv == 1 {
-				latencyOption := stat
-				if strings.Contains(latencyOption, "enable-") {
-					latencyOption = strings.ReplaceAll(latencyOption, "enable-", "")
+				latencySubcommand := stat
+				if strings.Contains(latencySubcommand, "enable-") {
+					latencySubcommand = strings.ReplaceAll(latencySubcommand, "enable-", "")
 				}
-				if strings.Contains(latencyOption, "hist-") {
-					latencyOption = strings.ReplaceAll(latencyOption, "hist-", "")
+				// some histogram command has 'hist-' prefix but the latency command does not expect hist- when issue the command
+				if strings.Contains(latencySubcommand, "hist-") {
+					latencySubcommand = strings.ReplaceAll(latencySubcommand, "hist-", "")
 				}
 
-				NodeLatencyBenchmarks[stat] = latencyOption
+				ServiceLatencyBenchmarks[stat] = latencySubcommand
+			} else {
+				// pv==0 means histogram is disabled
+				delete(ServiceLatencyBenchmarks, stat)
 			}
 		}
 	}

--- a/internal/pkg/statprocessors/sp_node_stats.go
+++ b/internal/pkg/statprocessors/sp_node_stats.go
@@ -1,6 +1,8 @@
 package statprocessors
 
 import (
+	"strings"
+
 	"github.com/aerospike/aerospike-prometheus-exporter/internal/pkg/commons"
 
 	log "github.com/sirupsen/logrus"
@@ -91,7 +93,15 @@ func (sw *NodeStatsProcessor) handleRefresh(nodeRawMetrics string) []AerospikeSt
 			delete(NodeLatencyBenchmarks, stat)
 
 			if pv == 1 {
-				NodeLatencyBenchmarks[stat] = stat
+				latencyOption := stat
+				if strings.Contains(latencyOption, "enable-") {
+					latencyOption = strings.ReplaceAll(latencyOption, "enable-", "")
+				}
+				if strings.Contains(latencyOption, "hist-") {
+					latencyOption = strings.ReplaceAll(latencyOption, "hist-", "")
+				}
+
+				NodeLatencyBenchmarks[stat] = latencyOption
 			}
 		}
 	}

--- a/internal/pkg/statprocessors/statsprocessor.go
+++ b/internal/pkg/statprocessors/statsprocessor.go
@@ -6,7 +6,9 @@ var (
 )
 
 var NodeLatencyBenchmarks = make(map[string]string)
-var NamespaceLatencyBenchmarks = make(map[string]map[string]string)
+var NamespaceLatencyBenchmarks = make(map[string]string)
+
+// var NamespaceLatencyBenchmarks = make(map[string]map[string]string)
 
 type StatProcessor interface {
 	PassOneKeys() []string

--- a/internal/pkg/statprocessors/statsprocessor.go
+++ b/internal/pkg/statprocessors/statsprocessor.go
@@ -5,10 +5,8 @@ var (
 	Service, ClusterName, Build string
 )
 
-var NodeLatencyBenchmarks = make(map[string]string)
-var NamespaceLatencyBenchmarks = make(map[string]string)
-
-// var NamespaceLatencyBenchmarks = make(map[string]map[string]string)
+var ServiceLatencyBenchmarks = make(map[string]string)
+var NamespaceLatencyBenchmarks = make(map[string]map[string]string)
 
 type StatProcessor interface {
 	PassOneKeys() []string

--- a/internal/pkg/statprocessors/statsprocessor.go
+++ b/internal/pkg/statprocessors/statsprocessor.go
@@ -5,7 +5,8 @@ var (
 	Service, ClusterName, Build string
 )
 
-var LatencyBenchmarks = make(map[string]string)
+var NodeLatencyBenchmarks = make(map[string]string)
+var NamespaceLatencyBenchmarks = make(map[string]map[string]string)
 
 type StatProcessor interface {
 	PassOneKeys() []string


### PR DESCRIPTION
this issue is occuring because namespace is append to the latencies command with a "-" and "-" (hypen) is part of the latency command itself, because of this command is constructed wrongly. a quick fix is use a separator which is not part of server command or output like "-","_",":" etc.,