### PR TITLE
OM-226 - bug fixes [ TLS not working when only server-pool is configured ] 

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -185,6 +185,11 @@ func (c *Config) ValidateAndUpdate(md toml.MetaData) {
 		log.Infof("Defaulting to Prometheus Exporting mode")
 		c.Agent.PrometheusEnabled = true
 	}
+
+	// validate Aerospike root-ca and cert-file configs
+	if len(Cfg.Aerospike.RootCA) == 0 && len(Cfg.Aerospike.CertFile) != 0 {
+		log.Fatalf("root_ca (Server Pool ) in Aerospike section cannot be null when Client Cert file is configured")
+	}
 }
 
 func (c *Config) FetchCloudInfo(md toml.MetaData) {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -186,10 +186,20 @@ func (c *Config) ValidateAndUpdate(md toml.MetaData) {
 		c.Agent.PrometheusEnabled = true
 	}
 
+	// key-file and cert-file either exist or not-exist together
+	if len(Cfg.Aerospike.KeyFile) == 0 && len(Cfg.Aerospike.CertFile) != 0 {
+		log.Fatalf("In Aerospike section, key_file is not present")
+	}
+
+	if len(Cfg.Aerospike.KeyFile) != 0 && len(Cfg.Aerospike.CertFile) == 0 {
+		log.Fatalf("In Aerospike section, cert_file is not present")
+	}
+
 	// validate Aerospike root-ca and cert-file configs
 	if len(Cfg.Aerospike.RootCA) == 0 && len(Cfg.Aerospike.CertFile) != 0 {
-		log.Fatalf("root_ca in Aerospike section cannot be null when cert_file is configured")
+		log.Fatalf("In Aerospike section, root_ca cannot be null when cert_file and key_file are configured")
 	}
+
 }
 
 func (c *Config) FetchCloudInfo(md toml.MetaData) {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -188,7 +188,7 @@ func (c *Config) ValidateAndUpdate(md toml.MetaData) {
 
 	// validate Aerospike root-ca and cert-file configs
 	if len(Cfg.Aerospike.RootCA) == 0 && len(Cfg.Aerospike.CertFile) != 0 {
-		log.Fatalf("root_ca (Server Pool ) in Aerospike section cannot be null when Client Cert file is configured")
+		log.Fatalf("root_ca in Aerospike section cannot be null when cert_file is configured")
 	}
 }
 

--- a/internal/pkg/dataprovider/aero_server.go
+++ b/internal/pkg/dataprovider/aero_server.go
@@ -98,8 +98,9 @@ func initAerospikeTLS() *tls.Config {
 	// load the server / client certificates
 	serverPool, clientPool = commons.LoadServerOrClientCertificates()
 
-	if serverPool != nil && clientPool != nil {
-		// we either have server pool or client pool of certificates
+	if serverPool != nil || clientPool != nil {
+		// we either have server pool only (oneway-tls) or both serverPool and clientPoll (mTLS)
+		// only clientPool without serverPool is invalid config.
 		tlsConfig := &tls.Config{
 			Certificates:             clientPool,
 			RootCAs:                  serverPool,

--- a/internal/pkg/statprocessors/statsrefresh.go
+++ b/internal/pkg/statprocessors/statsrefresh.go
@@ -43,7 +43,7 @@ func Refresh() ([]AerospikeStat, error) {
 	if Infokey_Service != INFOKEY_SERVICE_TLS_STD {
 		serverPool, clientPool := commons.LoadServerOrClientCertificates()
 		// we need to have atleast one certificate configured and read successfully
-		if serverPool != nil && clientPool != nil {
+		if serverPool != nil || clientPool != nil {
 			Infokey_Service = INFOKEY_SERVICE_TLS_STD
 			log.Debugf("TLS Mode is enabled, setting infokey-service as  'service-tls-std' for further fetching from server.")
 		}


### PR DESCRIPTION
fixed bug in tls certificate configurations during aerospike connection, we are forcing both root-ca and client-pool configure in case of oneway tls