### PR TITLE
docs: fix punctuation in README overview (test PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Aerospike Prometheus Exporter is now **generally available** (GA).
 If you're an enterprise customer feel free to reach out to support with any questions.
 We appreciate feedback from community members on the [issues](https://github.com/aerospike/aerospike-prometheus-exporter/issues).
 
-Aerospike agent exports various stats, config from Aerospike Server as metrics in OpenMetrics format,
+Aerospike agent exports various stats, config from Aerospike Server as metrics in OpenMetrics format.
 For more details about Aerospike Server Config refer [Aerospike System Config reference](https://aerospike.com/docs/database/reference/config) and for Aerospike Server Metrics refer [Aerospike System Metrics reference](https://aerospike.com/docs/database/reference/metrics).
 
 **NOTE:** Some of the metrics are pseudo metrics. A pseudo metric is neither a configuration nor a statistic in the server but is exposed as a metric by the agent. For more details, refer to the [Pseudo Metrics](#pseudo-metrics) section.


### PR DESCRIPTION
## Summary
- First test PR to get familiar with the team's review workflow.
- Documentation-only change: fixes a trailing comma that should be a period at the end of the exporter overview sentence in `README.md`.

## Test plan
- [ ] CI lint passes
- [ ] No functional changes (docs only)